### PR TITLE
adds guards for overflowing r/s values 

### DIFF
--- a/pkg/signer/errors.go
+++ b/pkg/signer/errors.go
@@ -6,4 +6,7 @@ import "errors"
 var (
 	// ErrInvalidPrivateKey is returned when a private key cannot be decoded or parsed.
 	ErrInvalidPrivateKey = errors.New("invalid private key")
+
+	// ErrInvalidSignature is returned when a signature has invalid components.
+	ErrInvalidSignature = errors.New("invalid signature")
 )


### PR DESCRIPTION
## Context

With untrusted input a caller could cause this library to panic if attempting to recover the signature from a payload which has an invalid R/S value. 

This PR guards against this scenario by checking R/S values in signing/decoding.

## Test plan

* [x] Added tests for serde and roundtripping with overflowing values 

As a follow up I want to add additional fuzz tests as well. This should come in the next few days 