### PR TITLE
refactor(tests): extract testContext for isolated test functionality

### DIFF
--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -127,18 +127,28 @@ func (tc *testContext) waitForBalance(address common.Address) {
 	tc.t.Fatalf("Failed to get balance for %s after 30s", address.Hex())
 }
 
-// fundAddress funds an address and waits for balance confirmation
+// fundAddress funds an address and waits for tx receipts and balance confirmation
 func (tc *testContext) fundAddress(address common.Address) {
 	tc.t.Helper()
+	var txHashes []string
 	for i := 0; i < 100; i++ {
 		resp, err := tc.client.SendRequest(tc.ctx, "tempo_fundAddress", address.Hex())
 		if err == nil && resp.Error == nil {
 			if result, ok := resp.Result.([]interface{}); ok && len(result) > 0 {
 				tc.t.Logf("Funded address %s", address.Hex())
+				for _, h := range result {
+					if hash, ok := h.(string); ok {
+						txHashes = append(txHashes, hash)
+					}
+				}
 				break
 			}
 		}
 		time.Sleep(200 * time.Millisecond)
+	}
+	// Wait for all funding tx receipts to ensure state is confirmed
+	for _, txHash := range txHashes {
+		tc.waitForReceipt(txHash)
 	}
 	tc.waitForBalance(address)
 }


### PR DESCRIPTION
## Summary

Refactors integration tests to use a `testContext` struct that encapsulates common test dependencies and helpers, reducing boilerplate and isolating functionality.

## Changes

- **`testContext` struct**: Encapsulates RPC client, chain ID, and gas price
- **`waitForBalance`**: Extracted as method, polls until address has non-zero balance
- **`sendTxExpectSuccess`**: Combines serialize → send → waitForReceipt → assert success
- **`newTxBuilder`**: Creates transaction builder with gas price defaults
- **`getNonce`**: Fetches current nonce for an address

## Before/After

**Before** (~15 lines per test):
```go
ctx := context.Background()
rpcClient := client.New(rpcURL)
cid := getChainID(t, rpcClient)
gasPrice := getGasPrice(t, rpcClient)
sender := createAndFundSigner(t, rpcClient)
// ... build tx ...
serialized, err := transaction.Serialize(tx, nil)
require.NoError(t, err)
txHash, err := rpcClient.SendRawTransaction(ctx, serialized)
require.NoError(t, err)
receipt := waitForReceipt(t, rpcClient, txHash)
require.NotNil(t, receipt)
status, _ := receipt["status"].(string)
require.Equal(t, "0x1", status)
```

**After** (~5 lines per test):
```go
tc := newTestContext(t)
sender := tc.createAndFundSigner()
tx := tc.newTxBuilder().SetNonce(tc.getNonce(sender.Address())).SetGas(300000).AddCall(...).Build()
transaction.SignTransaction(tx, sender)
tc.sendTxExpectSuccess(tx, "Transaction failed")
```

## Stats

```
1 file changed, 250 insertions(+), 476 deletions(-)
```

Builds on #13 (faucet balance wait fix).
