### PR TITLE
fix(client): accept *big.Int for nonce key in GetNonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- `client.GetNonce()` now accepts `*big.Int` instead of `uint64` for the nonce key parameter, enabling full 192-bit nonce key support as per the Tempo Transaction spec.
+
 ## [0.2.0] - 2026-01-27
 
 ### Security

--- a/examples/parallel-nonces/main.go
+++ b/examples/parallel-nonces/main.go
@@ -85,27 +85,27 @@ func main() {
 
 	// Define which nonce keys to use for parallel sends.
 	// These are fixed keys that can be reused once transactions confirm.
-	nonceKeys := []uint64{NonceKey1, NonceKey2, NonceKey3}
+	nonceKeys := []*big.Int{big.NewInt(NonceKey1), big.NewInt(NonceKey2), big.NewInt(NonceKey3)}
 
 	// Query the current nonce for each key in parallel.
-	nonces := make(map[uint64]uint64)
+	nonces := make(map[int64]uint64)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
 	log.Println("Fetching nonces for each key...")
 	for _, key := range nonceKeys {
 		wg.Add(1)
-		go func(nonceKey uint64) {
+		go func(nonceKey *big.Int) {
 			defer wg.Done()
 			nonce, err := rpcClient.GetNonce(ctx, sgn.Address().Hex(), nonceKey)
 			if err != nil {
-				log.Printf("Failed to get nonce for key %d: %v", nonceKey, err)
+				log.Printf("Failed to get nonce for key %d: %v", nonceKey.Int64(), err)
 				return
 			}
 			mu.Lock()
-			nonces[nonceKey] = nonce
+			nonces[nonceKey.Int64()] = nonce
 			mu.Unlock()
-			log.Printf("Nonce for key %d: %d", nonceKey, nonce)
+			log.Printf("Nonce for key %d: %d", nonceKey.Int64(), nonce)
 		}(key)
 	}
 	wg.Wait()
@@ -121,11 +121,11 @@ func main() {
 	log.Println("Sending transactions in parallel...")
 	for _, nonceKey := range nonceKeys {
 		wg.Add(1)
-		go func(key uint64, nonce uint64) {
+		go func(key *big.Int, nonce uint64) {
 			defer wg.Done()
 
 			tx := transaction.NewBuilder(big.NewInt(chainID)).
-				SetNonceKey(big.NewInt(int64(key))).
+				SetNonceKey(key).
 				SetNonce(nonce).
 				SetGas(100000).
 				SetMaxFeePerGas(big.NewInt(10000000000)).
@@ -152,8 +152,8 @@ func main() {
 			}
 
 			results <- txHash
-			log.Printf("Transaction with nonce key %d sent: %s", key, txHash)
-		}(nonceKey, nonces[nonceKey])
+			log.Printf("Transaction with nonce key %d sent: %s", key.Int64(), txHash)
+		}(nonceKey, nonces[nonceKey.Int64()])
 	}
 
 	wg.Wait()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -221,14 +222,18 @@ const nonceManagerAddress = "0x4e4F4E4345000000000000000000000000000000"
 
 // GetNonce gets the nonce for an address and nonce key using the Nonce Manager contract.
 // This is used for Tempo's 2D nonce system which enables parallel transaction submission.
-// Use nonceKey > 0 for parallel lanes; key 0 is the protocol nonce (use GetTransactionCount instead).
-func (c *Client) GetNonce(ctx context.Context, address string, nonceKey uint64) (uint64, error) {
+// The nonceKey is a 192-bit value; use nonceKey > 0 for parallel lanes.
+// Key 0 is the protocol nonce (use GetTransactionCount instead).
+func (c *Client) GetNonce(ctx context.Context, address string, nonceKey *big.Int) (uint64, error) {
+	if nonceKey == nil {
+		nonceKey = big.NewInt(0)
+	}
 	// Build the call data: selector + address (32 bytes) + nonceKey (32 bytes)
 	addr := strings.TrimPrefix(address, "0x")
 	// Pad address to 32 bytes (left-pad with zeros)
 	paddedAddr := fmt.Sprintf("%064s", addr)
-	// Pad nonceKey to 32 bytes (left-pad with zeros)
-	paddedKey := fmt.Sprintf("%064x", nonceKey)
+	// Pad nonceKey to 32 bytes (left-pad with zeros, big-endian hex)
+	paddedKey := fmt.Sprintf("%064s", nonceKey.Text(16))
 
 	callData := getNonceSelector + paddedAddr + paddedKey
 


### PR DESCRIPTION
## Summary

The nonce key is a 192-bit value per the Tempo Transaction spec, but `GetNonce()` previously accepted `uint64`, truncating to 64 bits.

## Changes

This changes the signature from:
```go
GetNonce(ctx, address string, nonceKey uint64) (uint64, error)
```
to:
```go
GetNonce(ctx, address string, nonceKey *big.Int) (uint64, error)
```

Also updates the `parallel-nonces` example to use the new signature.

## Breaking Change

This is a breaking change for callers of `client.GetNonce()`. Callers must now pass `*big.Int` instead of `uint64`:

```go
// Before
nonce, err := client.GetNonce(ctx, addr, 1)

// After
nonce, err := client.GetNonce(ctx, addr, big.NewInt(1))
```