### PR TITLE
fix(deserialize): overflow validation for uint64 fields

### DIFF
--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -2,6 +2,7 @@ package transaction
 
 import (
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -95,7 +96,11 @@ func Deserialize(serialized string) (*Tx, error) {
 
 	// Field 3: gas
 	if gas, ok := raw[3].([]byte); ok && len(gas) > 0 {
-		tx.Gas = new(big.Int).SetBytes(gas).Uint64()
+		v, err := bytesToUint64(gas)
+		if err != nil {
+			return nil, fmt.Errorf("gas %v", err)
+		}
+		tx.Gas = v
 	}
 
 	// Field 4: calls - array of [to, value, data] tuples
@@ -123,17 +128,29 @@ func Deserialize(serialized string) (*Tx, error) {
 
 	// Field 7: nonce
 	if nonce, ok := raw[7].([]byte); ok && len(nonce) > 0 {
-		tx.Nonce = new(big.Int).SetBytes(nonce).Uint64()
+		v, err := bytesToUint64(nonce)
+		if err != nil {
+			return nil, fmt.Errorf("nonce %v", err)
+		}
+		tx.Nonce = v
 	}
 
 	// Field 8: validBefore
 	if validBefore, ok := raw[8].([]byte); ok && len(validBefore) > 0 {
-		tx.ValidBefore = new(big.Int).SetBytes(validBefore).Uint64()
+		v, err := bytesToUint64(validBefore)
+		if err != nil {
+			return nil, fmt.Errorf("validBefore %v", err)
+		}
+		tx.ValidBefore = v
 	}
 
 	// Field 9: validAfter
 	if validAfter, ok := raw[9].([]byte); ok && len(validAfter) > 0 {
-		tx.ValidAfter = new(big.Int).SetBytes(validAfter).Uint64()
+		v, err := bytesToUint64(validAfter)
+		if err != nil {
+			return nil, fmt.Errorf("validAfter %v", err)
+		}
+		tx.ValidAfter = v
 	}
 
 	// Field 10: feeToken
@@ -391,4 +408,13 @@ func decodeSignatureEnvelope(envelopeBytes []byte) (*signer.SignatureEnvelope, e
 	default:
 		return nil, fmt.Errorf("unknown signature type prefix: 0x%02x", typePrefix)
 	}
+}
+
+// bytesToUint64 converts a byte slice to uint64, returning an error if it exceeds uint64 range.
+func bytesToUint64(b []byte) (uint64, error) {
+	v := new(big.Int).SetBytes(b)
+	if !v.IsUint64() {
+		return 0, errors.New("exceeds uint64 maximum")
+	}
+	return v.Uint64(), nil
 }

--- a/pkg/transaction/serialization_test.go
+++ b/pkg/transaction/serialization_test.go
@@ -619,15 +619,39 @@ func TestRoundtripWithOptions(t *testing.T) {
 	})
 }
 
-func TestDeserialize_OversizedSignature(t *testing.T) {
+func TestDeserialize_OversizedFields(t *testing.T) {
 	big33Bytes := new(big.Int).Lsh(big.NewInt(1), 256) // 33 bytes
 
 	tests := []struct {
-		name       string
-		r          []byte
-		s          []byte
-		wantErrStr string
+		name        string
+		gas         []byte
+		nonce       []byte
+		validBefore []byte
+		validAfter  []byte
+		r           []byte
+		s           []byte
+		wantErrStr  string
 	}{
+		{
+			name:       "oversized gas",
+			gas:        big33Bytes.Bytes(),
+			wantErrStr: "gas exceeds uint64 maximum",
+		},
+		{
+			name:       "oversized nonce",
+			nonce:      big33Bytes.Bytes(),
+			wantErrStr: "nonce exceeds uint64 maximum",
+		},
+		{
+			name:        "oversized validBefore",
+			validBefore: big33Bytes.Bytes(),
+			wantErrStr:  "validBefore exceeds uint64 maximum",
+		},
+		{
+			name:       "oversized validAfter",
+			validAfter: big33Bytes.Bytes(),
+			wantErrStr: "validAfter exceeds uint64 maximum",
+		},
 		{
 			name:       "oversized R in fee payer signature",
 			r:          big33Bytes.Bytes(),
@@ -648,7 +672,7 @@ func TestDeserialize_OversizedSignature(t *testing.T) {
 				big.NewInt(42424).Bytes(),   // chainId
 				big.NewInt(1000000).Bytes(), // maxPriorityFeePerGas
 				big.NewInt(2000000).Bytes(), // maxFeePerGas
-				big.NewInt(21000).Bytes(),   // gas
+				tt.gas,                      // gas
 				[]interface{}{ // calls
 					[]interface{}{
 						common.HexToAddress("0x1234567890123456789012345678901234567890").Bytes(),
@@ -656,12 +680,12 @@ func TestDeserialize_OversizedSignature(t *testing.T) {
 						[]byte{},
 					},
 				},
-				[]interface{}{},       // accessList
-				[]byte{},              // nonceKey
-				big.NewInt(1).Bytes(), // nonce
-				[]byte{},              // validBefore
-				[]byte{},              // validAfter
-				[]byte{},              // feeToken
+				[]interface{}{}, // accessList
+				[]byte{},        // nonceKey
+				tt.nonce,        // nonce
+				tt.validBefore,  // validBefore
+				tt.validAfter,   // validAfter
+				[]byte{},        // feeToken
 				[]interface{}{ // fee payer signature
 					[]byte{0},
 					tt.r,


### PR DESCRIPTION
## Summary
This PR adds `uint64` overflow validation during deserialization to prevent silent truncation from malicious RLP payloads.
## Changes
- Add uint64 overflow validation to `gas`, `nonce`, `validBefore`, and `validAfter` fields
- Extract repeated `big.Int` to `uint64` conversion and validation into a shared `bytesToUint64` helper
- Expand `TestDeserialize_OversizedSignatures` into `TestDeserialize_OversizedFields` to also cover all uint64 fields

## Testing
- [x] All Existing transaction package tests pass
- [x] New oversized field test cases assert correct error messages for gas, nonce, validBefore, validAfter

Closes https://github.com/tempoxyz/tempo-go/issues/17