### PR TITLE
fix: correct README examples, signer doc.go, and Validate nil checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ go get github.com/tempoxyz/tempo-go@v0.1.0
 package main
 
 import (
+    "context"
     "fmt"
     "math/big"
 
@@ -61,7 +62,7 @@ import (
 
 func main() {
     // Create RPC client
-    c, _ := client.New(transaction.RpcUrlMainnet)
+    c := client.New(transaction.RpcUrlModerato)
 
     s, _ := signer.NewSigner("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
 
@@ -80,8 +81,10 @@ func main() {
     }}
 
     transaction.SignTransaction(tx, s)
-    hash, _ := c.SendTransaction(tx)
-    fmt.Printf("Transaction hash: %s\n", hash.Hex())
+
+    serialized, _ := transaction.Serialize(tx, nil)
+    hash, _ := c.SendRawTransaction(context.Background(), serialized)
+    fmt.Printf("Transaction hash: %s\n", hash)
 }
 
 // buildERC20TransferData creates calldata for ERC20 transfer(address,uint256)
@@ -118,7 +121,8 @@ tx.Calls = []transaction.Call{{
 
 transaction.SignTransaction(tx, signer)
 
-client.SendTransaction(tx)
+serialized, _ := transaction.Serialize(tx, nil)
+client.SendRawTransaction(context.Background(), serialized)
 ```
 
 ### Sponsored Transaction
@@ -129,7 +133,8 @@ transaction.SignTransaction(tx, userSigner)
 
 transaction.AddFeePayerSignature(tx, feePayerSigner)
 
-client.SendTransaction(tx)
+serialized, _ := transaction.Serialize(tx, nil)
+client.SendRawTransaction(context.Background(), serialized)
 ```
 
 ### Batch Multiple Calls
@@ -144,7 +149,8 @@ tx.Calls = []transaction.Call{
 }
 
 transaction.SignTransaction(tx, signer)
-client.SendTransaction(tx)
+serialized, _ := transaction.Serialize(tx, nil)
+client.SendRawTransaction(context.Background(), serialized)
 ```
 
 ### Transaction with Validity Window
@@ -155,7 +161,8 @@ tx.ValidAfter = uint64(time.Now().Unix())
 tx.ValidBefore = uint64(time.Now().Add(1 * time.Hour).Unix())
 
 transaction.SignTransaction(tx, signer)
-client.SendTransaction(tx)
+serialized, _ := transaction.Serialize(tx, nil)
+client.SendRawTransaction(context.Background(), serialized)
 ```
 
 ## Packages
@@ -165,6 +172,7 @@ client.SendTransaction(tx)
 | `transaction` | TempoTransaction encoding, signing, and validation | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/transaction) |
 | `client`      | RPC client for interacting with Tempo nodes        | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/client)      |
 | `signer`      | Key management and signature generation            | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/signer)      |
+| `keychain`    | Keychain-based transaction signing                 | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/keychain)    |
 
 ## Testing
 
@@ -265,5 +273,5 @@ Licensed under either of [Apache License](./LICENSE-APACHE), Version
 2.0 or [MIT License](./LICENSE-MIT) at your option.
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in these crates by you, as defined in the Apache-2.0 license,
+for inclusion in these packages by you, as defined in the Apache-2.0 license,
 shall be dual licensed as above, without any additional terms or conditions.

--- a/pkg/signer/doc.go
+++ b/pkg/signer/doc.go
@@ -19,7 +19,7 @@
 // Sign data:
 //
 //	data := []byte("hello world")
-//	signature, err := signer.Sign(data)
+//	signature, err := signer.SignData(data)
 //	if err != nil {
 //		log.Fatal(err)
 //	}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -154,6 +154,14 @@ func (tx *Tx) Validate() error {
 		return fmt.Errorf("%w: chain ID must be set", ErrInvalidTransaction)
 	}
 
+	if tx.MaxFeePerGas == nil {
+		return fmt.Errorf("%w: max fee per gas must be set", ErrInvalidTransaction)
+	}
+
+	if tx.MaxPriorityFeePerGas == nil {
+		return fmt.Errorf("%w: max priority fee per gas must be set", ErrInvalidTransaction)
+	}
+
 	if tx.Gas == 0 {
 		return fmt.Errorf("%w: gas must be greater than 0", ErrInvalidTransaction)
 	}


### PR DESCRIPTION
## Summary

- **Fix 5 non-compiling README code examples** — `client.New()` returns a single value (not a tuple), `SendTransaction(tx)` doesn't exist (must use `Serialize()` + `SendRawTransaction()`), and `hash.Hex()` is called on a `string`
- **Fix `signer/doc.go` example** — `Sign()` takes `common.Hash`, not `[]byte`; the example should use `SignData()` instead
- **Add nil checks in `Validate()`** for `MaxFeePerGas` and `MaxPriorityFeePerGas` — prevents nil pointer panics in `Clone()` and `Serialize()`
- **Add missing `keychain` package** to the Packages documentation table
- **Fix "crates" → "packages"** terminology (Go, not Rust)

## Detailed Changes

### README.md

| Line(s) | Issue | Fix |
|---------|-------|-----|
| Quick Start | `c, _ := client.New(...)` won't compile — `New()` returns `*Client` | `c := client.New(...)` |
| Quick Start | `c.SendTransaction(tx)` doesn't exist | `transaction.Serialize(tx, nil)` + `c.SendRawTransaction(ctx, serialized)` |
| Quick Start | `hash.Hex()` called on `string` | `hash` (already a string) |
| Quick Start | Missing `context` import | Added `"context"` |
| Quick Start | Uses `RpcUrlMainnet` | Changed to `RpcUrlModerato` (testnet example) |
| 4 examples | `client.SendTransaction(tx)` | Same `Serialize` + `SendRawTransaction` pattern |
| Packages table | Missing `keychain` package | Added row |
| License | "crates" (Rust term) | "packages" (Go term) |

### pkg/signer/doc.go
- `signer.Sign(data)` where `data` is `[]byte` → `signer.SignData(data)` (correct method for `[]byte` input)

### pkg/transaction/transaction.go
- Added nil checks for `MaxFeePerGas` and `MaxPriorityFeePerGas` in `Validate()`, matching the existing pattern for `ChainID` and `NonceKey` nil checks

## Test plan

- [ ] Verify Quick Start example compiles with `go build`
- [ ] Verify `Validate()` returns error for nil `MaxFeePerGas`/`MaxPriorityFeePerGas`
- [ ] Run existing test suite: `make test`
- [ ] Verify `go doc github.com/tempoxyz/tempo-go/pkg/signer` shows correct example

