### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create release
+    runs-on: ubuntu-latest
+    environment: releases
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog for this version
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          NOTES=$(awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
+          echo "notes<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$NOTES" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.changelog.outputs.notes }}
+          generate_release_notes: false


### PR DESCRIPTION
Adds a GitHub Actions workflow that creates a GitHub Release when a `v*` tag is pushed.

- Extracts release notes from `CHANGELOG.md` automatically
- Uses a `releases` environment for required reviewer approval

**Setup needed after merge:** Create a "releases" environment in Settings → Environments with required reviewers set to maintainers.

**Release flow:**
1. Update `CHANGELOG.md`
2. `git tag v0.3.0 && git push origin v0.3.0`
3. Approve the release in GitHub Actions
4. GitHub Release is created, Go module proxy picks up the tag