### PR TITLE
feat: support T3 authorizeKey ABI in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,4 @@ jobs:
       run: go test -v -run TestIntegration -timeout=10m ./tests
       env:
         TEMPO_RPC_URL: ${{ secrets.TEMPO_TESTNET_RPC_URL }}
+        TEMPO_HARDFORK: T2

--- a/pkg/keychain/helpers.go
+++ b/pkg/keychain/helpers.go
@@ -58,8 +58,13 @@ func GetKeychainAddress() common.Address {
 	return common.HexToAddress(AccountKeychainAddress)
 }
 
-// AuthorizeKeySelector is the function selector for authorizeKey(address,uint8,uint64,bool,(address,uint256)[]).
+// AuthorizeKeySelector is the function selector for the legacy (pre-T3)
+// authorizeKey(address,uint8,uint64,bool,(address,uint256)[]).
 const AuthorizeKeySelector = "0x54063a55"
+
+// AuthorizeKeyT3Selector is the function selector for the T3+
+// authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]))
+const AuthorizeKeyT3Selector = "0x980a6025"
 
 // RevokeKeySelector is the function selector for revokeKey(address).
 const RevokeKeySelector = "0x5ae7ab32"

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -71,8 +71,8 @@ func init() {
 	}
 }
 
-func isT3() bool {
-	return hardfork >= "T3"
+func isT2() bool {
+	return hardfork == "T2"
 }
 
 // testContext encapsulates common test dependencies and helpers
@@ -928,7 +928,7 @@ func buildAuthorizeKeyCalldata(keyAddr common.Address, expiry int64, enforceLimi
 		enforceByte = 1
 	}
 
-	if !isT3() {
+	if isT2() {
 		return encodeCalldata(
 			authorizeKeySelector,
 			addressToBytes32(keyAddr),

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -58,12 +58,21 @@ func mustDecodeSelector(sel string) []byte {
 }
 
 var rpcURL string
+var hardfork string
 
 func init() {
 	rpcURL = os.Getenv("TEMPO_RPC_URL")
 	if rpcURL == "" {
 		panic("TEMPO_RPC_URL environment variable must be set to run integration tests. Example: export TEMPO_RPC_URL=https://rpc.moderato.tempo.xyz")
 	}
+	hardfork = os.Getenv("TEMPO_HARDFORK")
+	if hardfork == "" {
+		hardfork = "T3"
+	}
+}
+
+func isT3() bool {
+	return hardfork >= "T3"
 }
 
 // testContext encapsulates common test dependencies and helpers
@@ -579,15 +588,7 @@ func TestIntegration_AccessKeys(t *testing.T) {
 	t.Logf("Access key: %s", accessKey.Address().Hex())
 
 	t.Run("AuthorizeAccessKey", func(t *testing.T) {
-		calldata := encodeCalldata(
-			authorizeKeySelector,
-			addressToBytes32(accessKey.Address()),
-			padLeft32([]byte{0}),
-			uint256ToBytes32(big.NewInt(1893456000)),
-			padLeft32([]byte{0}),
-			uint256ToBytes32(big.NewInt(0xa0)),
-			uint256ToBytes32(big.NewInt(0)),
-		)
+		calldata := buildAuthorizeKeyCalldata(accessKey.Address(), 1893456000, false)
 
 		eip1559Tx := types.NewTx(&types.DynamicFeeTx{
 			ChainID:   big.NewInt(tc.chainID),
@@ -698,15 +699,7 @@ func TestIntegration_KeychainSelectors(t *testing.T) {
 	t.Logf("Access key: %s", accessKey.Address().Hex())
 
 	// Step 1: Authorize the key with enforceLimits=false, empty TokenLimit[]
-	authCalldata := encodeCalldata(
-		authorizeKeySelector,
-		addressToBytes32(accessKey.Address()),
-		padLeft32([]byte{0}), // Secp256k1
-		uint256ToBytes32(big.NewInt(expiry)),
-		padLeft32([]byte{0}),               // enforceLimits = false
-		uint256ToBytes32(big.NewInt(0xa0)), // offset to dynamic array
-		uint256ToBytes32(big.NewInt(0)),    // array length = 0
-	)
+	authCalldata := buildAuthorizeKeyCalldata(accessKey.Address(), expiry, false)
 
 	authTx := tc.newTxBuilder().
 		SetNonce(tc.getNonce(rootAccount.Address())).
@@ -925,6 +918,45 @@ func TestIntegration_SetUserFeeToken(t *testing.T) {
 // TestIntegration_DEXOperations tests DEX operations (skipped - require liquidity setup)
 func TestIntegration_DEXOperations(t *testing.T) {
 	t.Skip("DEX operations require liquidity setup - works with full tempo-check.sh flow")
+}
+
+// buildAuthorizeKeyCalldata builds ABI-encoded calldata for authorizeKey,
+// using the legacy flat-param ABI on pre-T3 and the KeyRestrictions struct on T3+.
+func buildAuthorizeKeyCalldata(keyAddr common.Address, expiry int64, enforceLimits bool) []byte {
+	enforceByte := byte(0)
+	if enforceLimits {
+		enforceByte = 1
+	}
+
+	if !isT3() {
+		return encodeCalldata(
+			authorizeKeySelector,
+			addressToBytes32(keyAddr),
+			padLeft32([]byte{0}),
+			uint256ToBytes32(big.NewInt(expiry)),
+			padLeft32([]byte{enforceByte}),
+			uint256ToBytes32(big.NewInt(0xa0)),
+			uint256ToBytes32(big.NewInt(0)),
+		)
+	}
+
+	// T3+: authorizeKey(address,uint8,KeyRestrictions)
+	// KeyRestrictions = (uint64 expiry, bool enforceLimits, TokenLimit[] limits, bool allowAnyCalls, CallScope[] allowedCalls)
+	sel := mustDecodeSelector(keychain.AuthorizeKeyT3Selector)
+	return encodeCalldata(
+		sel,
+		addressToBytes32(keyAddr),
+		padLeft32([]byte{0}),               // Secp256k1
+		uint256ToBytes32(big.NewInt(0x60)), // offset to KeyRestrictions tuple
+		// KeyRestrictions struct:
+		uint256ToBytes32(big.NewInt(expiry)),     // expiry
+		padLeft32([]byte{enforceByte}),           // enforceLimits
+		uint256ToBytes32(big.NewInt(0xa0)),       // offset to limits array (relative to struct start)
+		padLeft32([]byte{1}),                     // allowAnyCalls = true
+		uint256ToBytes32(big.NewInt(0xc0)),       // offset to allowedCalls array (relative to struct start)
+		uint256ToBytes32(big.NewInt(0)),          // limits.length = 0
+		uint256ToBytes32(big.NewInt(0)),          // allowedCalls.length = 0
+	)
 }
 
 // TestIntegration_BuilderValidation tests the BuildAndValidate method

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -949,13 +949,13 @@ func buildAuthorizeKeyCalldata(keyAddr common.Address, expiry int64, enforceLimi
 		padLeft32([]byte{0}),               // Secp256k1
 		uint256ToBytes32(big.NewInt(0x60)), // offset to KeyRestrictions tuple
 		// KeyRestrictions struct:
-		uint256ToBytes32(big.NewInt(expiry)),     // expiry
-		padLeft32([]byte{enforceByte}),           // enforceLimits
-		uint256ToBytes32(big.NewInt(0xa0)),       // offset to limits array (relative to struct start)
-		padLeft32([]byte{1}),                     // allowAnyCalls = true
-		uint256ToBytes32(big.NewInt(0xc0)),       // offset to allowedCalls array (relative to struct start)
-		uint256ToBytes32(big.NewInt(0)),          // limits.length = 0
-		uint256ToBytes32(big.NewInt(0)),          // allowedCalls.length = 0
+		uint256ToBytes32(big.NewInt(expiry)), // expiry
+		padLeft32([]byte{enforceByte}),       // enforceLimits
+		uint256ToBytes32(big.NewInt(0xa0)),   // offset to limits array (relative to struct start)
+		padLeft32([]byte{1}),                 // allowAnyCalls = true
+		uint256ToBytes32(big.NewInt(0xc0)),   // offset to allowedCalls array (relative to struct start)
+		uint256ToBytes32(big.NewInt(0)),      // limits.length = 0
+		uint256ToBytes32(big.NewInt(0)),      // allowedCalls.length = 0
 	)
 }
 


### PR DESCRIPTION
Integration tests fail on T3 devnets because `authorizeKey` uses the legacy flat-param ABI which T3 nodes reject (`UnknownFunctionSelector(0x19f191e2)`).

## Changes

- **`pkg/keychain/helpers.go`**: Add `AuthorizeKeyT3Selector` (`0x980a6025`) for the T3+ `authorizeKey(address,uint8,KeyRestrictions)` overload
- **`tests/integration_test.go`**: Read `TEMPO_HARDFORK` env var (default `T3`), build correct calldata per hardfork via `buildAuthorizeKeyCalldata()` helper

Set `TEMPO_HARDFORK=T2` to run against pre-T3 nodes.

## Testing

```
TEMPO_HARDFORK=T3 TEMPO_RPC_URL=<rpc> go test -v -run TestIntegration -timeout=10m ./tests
```

Prompted by: georgen