### PR TITLE
refactor(keychain): add call scope restrictions, builder, and call encoders

### DIFF
--- a/pkg/keychain/calls.go
+++ b/pkg/keychain/calls.go
@@ -1,0 +1,244 @@
+package keychain
+
+import (
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SetAllowedCallsSelector is the function selector for
+// setAllowedCalls(address,(address,(bytes4,address[])[])[]).
+const SetAllowedCallsSelector = "0xf5456703"
+
+// RemoveAllowedCallsSelector is the function selector for
+// removeAllowedCalls(address,address).
+const RemoveAllowedCallsSelector = "0xf3941811"
+
+// SignatureType constants matching the Rust/Solidity enum.
+const (
+	SignatureTypeSecp256k1 = 0
+	SignatureTypeP256      = 1
+	SignatureTypeWebAuthn  = 2
+)
+
+// abiSelectorRule is the Go struct that matches the ABI tuple encoding.
+type abiSelectorRule struct {
+	Selector   [4]byte          `abi:"selector"`
+	Recipients []common.Address `abi:"recipients"`
+}
+
+// abiCallScope is the Go struct that matches the ABI tuple encoding.
+type abiCallScope struct {
+	Target        common.Address    `abi:"target"`
+	SelectorRules []abiSelectorRule `abi:"selectorRules"`
+}
+
+// abiTokenLimit matches the ABI tuple (address, uint256, uint64).
+type abiTokenLimit struct {
+	Token  common.Address `abi:"token"`
+	Amount *big.Int       `abi:"amount"`
+	Period uint64         `abi:"period"`
+}
+
+// abiKeyRestrictions matches the ABI tuple for KeyRestrictions.
+type abiKeyRestrictions struct {
+	Expiry        uint64          `abi:"expiry"`
+	EnforceLimits bool            `abi:"enforceLimits"`
+	Limits        []abiTokenLimit `abi:"limits"`
+	AllowAnyCalls bool            `abi:"allowAnyCalls"`
+	AllowedCalls  []abiCallScope  `abi:"allowedCalls"`
+}
+
+func toABICallScopes(scopes []CallScope) []abiCallScope {
+	result := make([]abiCallScope, len(scopes))
+	for i, s := range scopes {
+		rules := make([]abiSelectorRule, len(s.SelectorRules))
+		for j, r := range s.SelectorRules {
+			recipients := make([]common.Address, len(r.Recipients))
+			copy(recipients, r.Recipients)
+			rules[j] = abiSelectorRule{
+				Selector:   r.Selector,
+				Recipients: recipients,
+			}
+		}
+		result[i] = abiCallScope{
+			Target:        s.Target,
+			SelectorRules: rules,
+		}
+	}
+	return result
+}
+
+// Call represents an EVM call with target address and calldata.
+type Call struct {
+	To   common.Address
+	Data []byte
+}
+
+// keychainAddress is the precompile address.
+var keychainAddress = common.HexToAddress(AccountKeychainAddress)
+
+// authorizeKeyABI is the parsed ABI for authorizeKey(address,uint8,KeyRestrictions).
+var authorizeKeyABI abi.ABI
+
+// setAllowedCallsABI is the parsed ABI for setAllowedCalls(address,CallScope[]).
+var setAllowedCallsABI abi.ABI
+
+// removeAllowedCallsABI is the parsed ABI for removeAllowedCalls(address,address).
+var removeAllowedCallsABI abi.ABI
+
+// revokeKeyABI is the parsed ABI for revokeKey(address).
+var revokeKeyABI abi.ABI
+
+// updateSpendingLimitABI is the parsed ABI for updateSpendingLimit(address,address,uint256).
+var updateSpendingLimitABI abi.ABI
+
+func mustParseABI(json string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse ABI: %v", err))
+	}
+	return parsed
+}
+
+func init() {
+	authorizeKeyABI = mustParseABI(`[{
+		"name": "authorizeKey",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "signatureType", "type": "uint8"},
+			{"name": "restrictions", "type": "tuple", "components": [
+				{"name": "expiry", "type": "uint64"},
+				{"name": "enforceLimits", "type": "bool"},
+				{"name": "limits", "type": "tuple[]", "components": [
+					{"name": "token", "type": "address"},
+					{"name": "amount", "type": "uint256"},
+					{"name": "period", "type": "uint64"}
+				]},
+				{"name": "allowAnyCalls", "type": "bool"},
+				{"name": "allowedCalls", "type": "tuple[]", "components": [
+					{"name": "target", "type": "address"},
+					{"name": "selectorRules", "type": "tuple[]", "components": [
+						{"name": "selector", "type": "bytes4"},
+						{"name": "recipients", "type": "address[]"}
+					]}
+				]}
+			]}
+		]
+	}]`)
+
+	setAllowedCallsABI = mustParseABI(`[{
+		"name": "setAllowedCalls",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "scopes", "type": "tuple[]", "components": [
+				{"name": "target", "type": "address"},
+				{"name": "selectorRules", "type": "tuple[]", "components": [
+					{"name": "selector", "type": "bytes4"},
+					{"name": "recipients", "type": "address[]"}
+				]}
+			]}
+		]
+	}]`)
+
+	removeAllowedCallsABI = mustParseABI(`[{
+		"name": "removeAllowedCalls",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "target", "type": "address"}
+		]
+	}]`)
+
+	revokeKeyABI = mustParseABI(`[{
+		"name": "revokeKey",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"}
+		]
+	}]`)
+
+	updateSpendingLimitABI = mustParseABI(`[{
+		"name": "updateSpendingLimit",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "token", "type": "address"},
+			{"name": "newLimit", "type": "uint256"}
+		]
+	}]`)
+}
+
+// AuthorizeKey builds an authorizeKey(address,uint8,KeyRestrictions) call.
+func AuthorizeKey(keyID common.Address, signatureType uint8, restrictions *KeyRestrictions) (Call, error) {
+	if restrictions == nil {
+		return Call{}, fmt.Errorf("restrictions must not be nil")
+	}
+	if err := restrictions.Validate(); err != nil {
+		return Call{}, fmt.Errorf("invalid restrictions: %w", err)
+	}
+
+	limits := make([]abiTokenLimit, len(restrictions.limits))
+	for i, l := range restrictions.limits {
+		limits[i] = abiTokenLimit{
+			Token:  l.Token,
+			Amount: l.Amount,
+			Period: l.Period,
+		}
+	}
+
+	r := abiKeyRestrictions{
+		Expiry:        restrictions.expiry,
+		EnforceLimits: restrictions.enforceLimits,
+		Limits:        limits,
+		AllowAnyCalls: restrictions.allowAnyCalls,
+		AllowedCalls:  toABICallScopes(restrictions.allowedCalls),
+	}
+
+	data, err := authorizeKeyABI.Pack("authorizeKey", keyID, signatureType, r)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode authorizeKey: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// RevokeKey builds a revokeKey(address) call.
+func RevokeKey(keyID common.Address) (Call, error) {
+	data, err := revokeKeyABI.Pack("revokeKey", keyID)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode revokeKey: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// SetAllowedCalls builds a setAllowedCalls(address,CallScope[]) call.
+func SetAllowedCalls(keyID common.Address, scopes []CallScope) (Call, error) {
+	data, err := setAllowedCallsABI.Pack("setAllowedCalls", keyID, toABICallScopes(scopes))
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode setAllowedCalls: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// RemoveAllowedCalls builds a removeAllowedCalls(address,address) call.
+func RemoveAllowedCalls(keyID common.Address, target common.Address) (Call, error) {
+	data, err := removeAllowedCallsABI.Pack("removeAllowedCalls", keyID, target)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode removeAllowedCalls: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// UpdateSpendingLimit builds an updateSpendingLimit(address,address,uint256) call.
+func UpdateSpendingLimit(keyID common.Address, token common.Address, newLimit *big.Int) (Call, error) {
+	data, err := updateSpendingLimitABI.Pack("updateSpendingLimit", keyID, token, newLimit)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode updateSpendingLimit: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}

--- a/pkg/keychain/calls_test.go
+++ b/pkg/keychain/calls_test.go
@@ -1,0 +1,197 @@
+package keychain
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestAuthorizeKey_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	kr := NewKeyRestrictions(1000)
+
+	call, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, kr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestAuthorizeKey_WithAllowedCalls(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	scope := NewCallScopeBuilder(token).Transfer(nil).Build()
+
+	kr := NewKeyRestrictions(1000).WithAllowedCalls([]CallScope{scope})
+
+	call, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, kr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestAuthorizeKey_NilRestrictions(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	_, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, nil)
+	if err == nil {
+		t.Error("expected error for nil restrictions")
+	}
+}
+
+func TestAuthorizeKey_RejectsConflict(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	scope := NewCallScopeBuilder(token).Transfer(nil).Build()
+
+	kr := NewKeyRestrictions(1000)
+	kr.allowAnyCalls = true
+	kr.allowedCalls = []CallScope{scope}
+
+	_, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, kr)
+	if err == nil {
+		t.Error("expected error for conflicting allowAnyCalls + allowedCalls")
+	}
+}
+
+func TestAuthorizeKey_WithRecipients(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	recipient := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	scope := NewCallScopeBuilder(token).Transfer([]common.Address{recipient}).Build()
+
+	kr := NewKeyRestrictions(1000).WithAllowedCalls([]CallScope{scope})
+
+	call, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, kr)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestRevokeKey_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	call, err := RevokeKey(keyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestSetAllowedCalls_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	scope := NewCallScopeBuilder(token).Transfer(nil).Build()
+
+	call, err := SetAllowedCalls(keyID, []CallScope{scope})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestSetAllowedCalls_WithRecipients(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	recipient := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	scope := NewCallScopeBuilder(token).Transfer([]common.Address{recipient}).Build()
+
+	call, err := SetAllowedCalls(keyID, []CallScope{scope})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestSetAllowedCalls_WithSelector(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	target := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	sel := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	scope := NewCallScopeBuilder(target).WithSelector(sel).Build()
+
+	call, err := SetAllowedCalls(keyID, []CallScope{scope})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestRemoveAllowedCalls_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	target := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	call, err := RemoveAllowedCalls(keyID, target)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestUpdateSpendingLimit_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+
+	call, err := UpdateSpendingLimit(keyID, token, big.NewInt(1000))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+}
+
+func TestFunctionSelectors_Calls(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector string
+		sig      string
+	}{
+		{"SetAllowedCalls", SetAllowedCallsSelector, "setAllowedCalls(address,(address,(bytes4,address[])[])[])"}, //nolint:lll
+		{"RemoveAllowedCalls", RemoveAllowedCallsSelector, "removeAllowedCalls(address,address)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hash := crypto.Keccak256([]byte(tt.sig))
+			got := "0x" + hex.EncodeToString(hash[:4])
+			if got != tt.selector {
+				t.Errorf("selector mismatch for %s: expected %s, got %s", tt.sig, tt.selector, got)
+			}
+		})
+	}
+}

--- a/pkg/keychain/doc.go
+++ b/pkg/keychain/doc.go
@@ -2,7 +2,8 @@
 //
 // The AccountKeychain precompile manages authorized Access Keys for accounts,
 // enabling Root Keys (e.g., passkeys) to provision scoped "secondary" Access Keys
-// with expiry timestamps and per-TIP20 token spending limits.
+// with expiry timestamps, per-TIP20 token spending limits, and call scope
+// restrictions (per-contract, per-selector, and per-recipient filtering).
 //
 // # Keychain V2 Signature Format
 //
@@ -32,12 +33,31 @@
 //	accessKeySigner, _ := signer.NewSigner(accessKeyPrivateKey)
 //	err := keychain.SignWithAccessKey(tx, accessKeySigner, rootAccount)
 //
+// # Call Scope Restrictions
+//
+// Access keys can be scoped to specific contracts, function selectors, and
+// recipients using [CallScope] and [SelectorRule]. Use [CallScopeBuilder] to
+// construct scopes:
+//
+//	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+//	scope := keychain.NewCallScopeBuilder(token).
+//		Transfer([]common.Address{recipient}).
+//		Approve(nil).
+//		Build()
+//
+//	restrictions := keychain.NewKeyRestrictions(expiry).
+//		WithAllowedCalls([]keychain.CallScope{scope})
+//
+//	call, _ := keychain.AuthorizeKey(keyID, keychain.SignatureTypeSecp256k1, restrictions)
+//
 // # AccountKeychain Precompile
 //
 // The precompile is located at address 0xAAAAAAAA00000000000000000000000000000000.
 // It provides functions for:
-//   - authorizeKey: Authorize a new access key with optional spending limits
+//   - authorizeKey: Authorize a new access key with restrictions
 //   - revokeKey: Revoke an access key
 //   - updateSpendingLimit: Update spending limit for a token
+//   - setAllowedCalls: Set or replace call scope restrictions for a key
+//   - removeAllowedCalls: Remove call scope rules for a key+target pair
 //   - getRemainingLimit: Query remaining spending limit
 package keychain

--- a/pkg/keychain/restrictions.go
+++ b/pkg/keychain/restrictions.go
@@ -1,0 +1,247 @@
+package keychain
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TIP20 function selectors.
+var (
+	SelectorTransfer         = [4]byte{0xa9, 0x05, 0x9c, 0xbb} // transfer(address,uint256)
+	SelectorApprove          = [4]byte{0x09, 0x5e, 0xa7, 0xb3} // approve(address,uint256)
+	SelectorTransferWithMemo = [4]byte{0x44, 0x7b, 0x73, 0x2f} // transferWithMemo(address,uint256,bytes32)
+	SelectorWildcard         = [4]byte{0x00, 0x00, 0x00, 0x00}
+)
+
+// SelectorRule restricts a single function selector to an optional set of
+// first-argument (recipient) addresses. An empty Recipients list means any
+// recipient is allowed.
+type SelectorRule struct {
+	Selector   [4]byte
+	Recipients []common.Address
+}
+
+// CallScope restricts the calls an access key may make to a single target
+// contract, optionally scoped to specific function selectors and recipients.
+type CallScope struct {
+	Target        common.Address
+	SelectorRules []SelectorRule
+}
+
+// CallScopeBuilder builds a CallScope with a fluent API.
+type CallScopeBuilder struct {
+	target        common.Address
+	selectorRules []SelectorRule
+}
+
+// NewCallScopeBuilder creates a builder for the given target contract.
+func NewCallScopeBuilder(target common.Address) *CallScopeBuilder {
+	return &CallScopeBuilder{target: target}
+}
+
+// WithSelector allows calls matching an arbitrary 4-byte function selector.
+func (b *CallScopeBuilder) WithSelector(selector [4]byte) *CallScopeBuilder {
+	b.selectorRules = append(b.selectorRules, SelectorRule{
+		Selector: selector,
+	})
+	return b
+}
+
+// Transfer allows transfer(address,uint256) calls, optionally restricted to
+// the given recipients.
+func (b *CallScopeBuilder) Transfer(recipients []common.Address) *CallScopeBuilder {
+	b.selectorRules = append(b.selectorRules, SelectorRule{
+		Selector:   SelectorTransfer,
+		Recipients: recipients,
+	})
+	return b
+}
+
+// Approve allows approve(address,uint256) calls, optionally restricted to the
+// given spender addresses.
+func (b *CallScopeBuilder) Approve(recipients []common.Address) *CallScopeBuilder {
+	b.selectorRules = append(b.selectorRules, SelectorRule{
+		Selector:   SelectorApprove,
+		Recipients: recipients,
+	})
+	return b
+}
+
+// TransferWithMemo allows transferWithMemo(address,uint256,bytes32) calls,
+// optionally restricted to the given recipients.
+func (b *CallScopeBuilder) TransferWithMemo(recipients []common.Address) *CallScopeBuilder {
+	b.selectorRules = append(b.selectorRules, SelectorRule{
+		Selector:   SelectorTransferWithMemo,
+		Recipients: recipients,
+	})
+	return b
+}
+
+// Unrestricted allows any call to the target (wildcard selector, no recipient
+// filtering).
+func (b *CallScopeBuilder) Unrestricted() *CallScopeBuilder {
+	b.selectorRules = nil
+	return b
+}
+
+// Build returns the constructed CallScope.
+func (b *CallScopeBuilder) Build() CallScope {
+	rules := make([]SelectorRule, len(b.selectorRules))
+	copy(rules, b.selectorRules)
+	return CallScope{
+		Target:        b.target,
+		SelectorRules: rules,
+	}
+}
+
+// TokenLimit represents a per-token spending limit for an access key.
+type TokenLimit struct {
+	Token  common.Address
+	Amount *big.Int
+	Period uint64
+}
+
+// KeyRestrictions holds all the restrictions for an access key.
+type KeyRestrictions struct {
+	expiry        uint64
+	enforceLimits bool
+	limits        []TokenLimit
+	allowAnyCalls bool
+	allowedCalls  []CallScope
+}
+
+// NewKeyRestrictions creates an unrestricted KeyRestrictions with the given
+// expiry. Calls are unrestricted by default (allowAnyCalls=true).
+func NewKeyRestrictions(expiry uint64) *KeyRestrictions {
+	return &KeyRestrictions{
+		expiry:        expiry,
+		allowAnyCalls: true,
+	}
+}
+
+// WithEnforceLimits sets the enforceLimits flag.
+func (kr *KeyRestrictions) WithEnforceLimits(enforce bool) *KeyRestrictions {
+	kr.enforceLimits = enforce
+	return kr
+}
+
+// WithLimits sets the token spending limits.
+func (kr *KeyRestrictions) WithLimits(limits []TokenLimit) *KeyRestrictions {
+	kr.limits = limits
+	kr.enforceLimits = len(limits) > 0
+	return kr
+}
+
+// WithAllowedCalls sets the call-scope allowlist and disables allowAnyCalls.
+func (kr *KeyRestrictions) WithAllowedCalls(scopes []CallScope) *KeyRestrictions {
+	kr.allowedCalls = scopes
+	kr.allowAnyCalls = false
+	return kr
+}
+
+// WithNoCalls sets an empty call-scope allowlist (deny all calls).
+func (kr *KeyRestrictions) WithNoCalls() *KeyRestrictions {
+	kr.allowedCalls = []CallScope{}
+	kr.allowAnyCalls = false
+	return kr
+}
+
+// IsUnrestricted returns true if calls are unrestricted.
+func (kr *KeyRestrictions) IsUnrestricted() bool {
+	return kr.allowAnyCalls
+}
+
+// IsCallAllowed checks whether a call to target with the given input data is
+// permitted by these restrictions.
+func (kr *KeyRestrictions) IsCallAllowed(target common.Address, input []byte) bool {
+	if kr.allowAnyCalls {
+		return true
+	}
+
+	// Find a matching scope for the target.
+	var scope *CallScope
+	for i := range kr.allowedCalls {
+		if kr.allowedCalls[i].Target == target {
+			scope = &kr.allowedCalls[i]
+			break
+		}
+	}
+	if scope == nil {
+		return false
+	}
+
+	// No selector rules means any call to this target is allowed.
+	if len(scope.SelectorRules) == 0 {
+		return true
+	}
+
+	// Need at least a 4-byte selector in the input.
+	if len(input) < 4 {
+		return false
+	}
+	var sel [4]byte
+	copy(sel[:], input[:4])
+
+	// Find a matching rule.
+	var rule *SelectorRule
+	for i := range scope.SelectorRules {
+		if scope.SelectorRules[i].Selector == sel {
+			rule = &scope.SelectorRules[i]
+			break
+		}
+	}
+	if rule == nil {
+		return false
+	}
+
+	// No recipient filtering.
+	if len(rule.Recipients) == 0 {
+		return true
+	}
+
+	// Need at least selector + 32-byte word for the first argument.
+	if len(input) < 36 {
+		return false
+	}
+	recipient := common.BytesToAddress(input[4:36])
+	for _, allowed := range rule.Recipients {
+		if allowed == recipient {
+			return true
+		}
+	}
+	return false
+}
+
+// Expiry returns the expiry timestamp.
+func (kr *KeyRestrictions) Expiry() uint64 {
+	return kr.expiry
+}
+
+// Limits returns the token spending limits.
+func (kr *KeyRestrictions) Limits() []TokenLimit {
+	return kr.limits
+}
+
+// AllowedCalls returns the call scope allowlist.
+func (kr *KeyRestrictions) AllowedCalls() []CallScope {
+	return kr.allowedCalls
+}
+
+// Validate checks for conflicting settings.
+func (kr *KeyRestrictions) Validate() error {
+	if kr.allowAnyCalls && len(kr.allowedCalls) > 0 {
+		return errors.New("allowedCalls was provided but allowAnyCalls=true; set allowAnyCalls=false to create a scoped key")
+	}
+	// Reject duplicate targets — order-dependent IsCallAllowed behaviour is confusing.
+	seen := make(map[common.Address]struct{}, len(kr.allowedCalls))
+	for _, s := range kr.allowedCalls {
+		if _, exists := seen[s.Target]; exists {
+			return fmt.Errorf("duplicate CallScope target: %s", s.Target.Hex())
+		}
+		seen[s.Target] = struct{}{}
+	}
+	return nil
+}

--- a/pkg/keychain/restrictions_test.go
+++ b/pkg/keychain/restrictions_test.go
@@ -1,0 +1,305 @@
+package keychain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestCallScopeBuilder_Build(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).Build()
+
+	if scope.Target != target {
+		t.Errorf("expected target %s, got %s", target.Hex(), scope.Target.Hex())
+	}
+	if len(scope.SelectorRules) != 0 {
+		t.Errorf("expected 0 rules, got %d", len(scope.SelectorRules))
+	}
+}
+
+func TestCallScopeBuilder_WithSelector(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	sel := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	scope := NewCallScopeBuilder(target).WithSelector(sel).Build()
+
+	if len(scope.SelectorRules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(scope.SelectorRules))
+	}
+	if scope.SelectorRules[0].Selector != sel {
+		t.Errorf("selector mismatch")
+	}
+	if len(scope.SelectorRules[0].Recipients) != 0 {
+		t.Errorf("expected 0 recipients, got %d", len(scope.SelectorRules[0].Recipients))
+	}
+}
+
+func TestCallScopeBuilder_Transfer(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	recipient := common.HexToAddress("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	scope := NewCallScopeBuilder(target).Transfer([]common.Address{recipient}).Build()
+
+	if len(scope.SelectorRules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(scope.SelectorRules))
+	}
+	if scope.SelectorRules[0].Selector != SelectorTransfer {
+		t.Errorf("expected transfer selector")
+	}
+	if len(scope.SelectorRules[0].Recipients) != 1 {
+		t.Errorf("expected 1 recipient, got %d", len(scope.SelectorRules[0].Recipients))
+	}
+}
+
+func TestCallScopeBuilder_TransferNoRecipients(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).Transfer(nil).Build()
+
+	if scope.SelectorRules[0].Selector != SelectorTransfer {
+		t.Errorf("expected transfer selector")
+	}
+	if len(scope.SelectorRules[0].Recipients) != 0 {
+		t.Errorf("expected 0 recipients")
+	}
+}
+
+func TestCallScopeBuilder_Approve(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).Approve(nil).Build()
+
+	if scope.SelectorRules[0].Selector != SelectorApprove {
+		t.Errorf("expected approve selector")
+	}
+}
+
+func TestCallScopeBuilder_TransferWithMemo(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).TransferWithMemo(nil).Build()
+
+	if scope.SelectorRules[0].Selector != SelectorTransferWithMemo {
+		t.Errorf("expected transferWithMemo selector")
+	}
+}
+
+func TestCallScopeBuilder_Chained(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).
+		Transfer(nil).
+		Approve(nil).
+		Build()
+
+	if len(scope.SelectorRules) != 2 {
+		t.Errorf("expected 2 rules, got %d", len(scope.SelectorRules))
+	}
+}
+
+func TestCallScopeBuilder_Unrestricted(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).
+		Transfer(nil).
+		Unrestricted().
+		Build()
+
+	if len(scope.SelectorRules) != 0 {
+		t.Errorf("expected 0 rules after unrestricted, got %d", len(scope.SelectorRules))
+	}
+}
+
+func TestKeyRestrictions_IsUnrestricted(t *testing.T) {
+	kr := NewKeyRestrictions(0)
+	if !kr.IsUnrestricted() {
+		t.Error("default should be unrestricted")
+	}
+}
+
+func TestKeyRestrictions_WithAllowedCalls(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).Transfer(nil).Build()
+
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{scope})
+	if kr.IsUnrestricted() {
+		t.Error("should not be unrestricted after WithAllowedCalls")
+	}
+	if len(kr.AllowedCalls()) != 1 {
+		t.Errorf("expected 1 scope, got %d", len(kr.AllowedCalls()))
+	}
+}
+
+func TestKeyRestrictions_WithNoCalls(t *testing.T) {
+	kr := NewKeyRestrictions(0).WithNoCalls()
+	if kr.IsUnrestricted() {
+		t.Error("should not be unrestricted")
+	}
+	if len(kr.AllowedCalls()) != 0 {
+		t.Errorf("expected 0 scopes, got %d", len(kr.AllowedCalls()))
+	}
+}
+
+func TestKeyRestrictions_Validate(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope := NewCallScopeBuilder(target).Build()
+
+	// allowAnyCalls=true with non-empty allowedCalls should fail.
+	kr := NewKeyRestrictions(0)
+	kr.allowedCalls = []CallScope{scope}
+	kr.allowAnyCalls = true
+
+	if err := kr.Validate(); err == nil {
+		t.Error("expected validation error")
+	}
+}
+
+func TestKeyRestrictions_WithLimits(t *testing.T) {
+	kr := NewKeyRestrictions(1000).WithLimits([]TokenLimit{
+		{Token: common.HexToAddress("0x20c0000000000000000000000000000000000001"), Amount: big.NewInt(100), Period: 0},
+	})
+	if !kr.enforceLimits {
+		t.Error("enforceLimits should be true when limits are set")
+	}
+	if len(kr.Limits()) != 1 {
+		t.Errorf("expected 1 limit, got %d", len(kr.Limits()))
+	}
+}
+
+func TestKeyRestrictions_ValidateRejectsDuplicateTargets(t *testing.T) {
+	target := common.HexToAddress("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	scope1 := NewCallScopeBuilder(target).Transfer(nil).Build()
+	scope2 := NewCallScopeBuilder(target).Approve(nil).Build()
+
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{scope1, scope2})
+	if err := kr.Validate(); err == nil {
+		t.Error("expected error for duplicate targets")
+	}
+}
+
+// --- IsCallAllowed tests ---
+
+func TestIsCallAllowed_Unrestricted(t *testing.T) {
+	kr := NewKeyRestrictions(0)
+	target := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	if !kr.IsCallAllowed(target, nil) {
+		t.Error("unrestricted should allow any call")
+	}
+	if !kr.IsCallAllowed(target, []byte{0xaa, 0xbb, 0xcc, 0xdd}) {
+		t.Error("unrestricted should allow any call with data")
+	}
+}
+
+func TestIsCallAllowed_NoCalls(t *testing.T) {
+	kr := NewKeyRestrictions(0).WithNoCalls()
+	target := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	if kr.IsCallAllowed(target, []byte{0xaa, 0xbb, 0xcc, 0xdd}) {
+		t.Error("no-calls should deny everything")
+	}
+}
+
+func TestIsCallAllowed_TargetNotInScope(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	other := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).Build(),
+	})
+	if kr.IsCallAllowed(other, []byte{0xaa, 0xbb, 0xcc, 0xdd}) {
+		t.Error("call to non-scoped target should be denied")
+	}
+}
+
+func TestIsCallAllowed_NoSelectorRulesAllowsAny(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).Build(),
+	})
+	if !kr.IsCallAllowed(token, []byte{0xaa, 0xbb, 0xcc, 0xdd}) {
+		t.Error("no selector rules should allow any call to target")
+	}
+	if !kr.IsCallAllowed(token, nil) {
+		t.Error("no selector rules should allow empty input")
+	}
+}
+
+func TestIsCallAllowed_SelectorMatch(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	sel := [4]byte{0xaa, 0xbb, 0xcc, 0xdd}
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).WithSelector(sel).Build(),
+	})
+
+	if !kr.IsCallAllowed(token, []byte{0xaa, 0xbb, 0xcc, 0xdd}) {
+		t.Error("matching selector should be allowed")
+	}
+	if kr.IsCallAllowed(token, []byte{0x11, 0x22, 0x33, 0x44}) {
+		t.Error("non-matching selector should be denied")
+	}
+	if kr.IsCallAllowed(token, []byte{0xaa, 0xbb}) {
+		t.Error("too-short input should be denied")
+	}
+}
+
+func TestIsCallAllowed_TransferWithRecipients(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	allowed := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	denied := common.HexToAddress("0x5555555555555555555555555555555555555555")
+
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).Transfer([]common.Address{allowed}).Build(),
+	})
+
+	// Build valid transfer calldata: selector + padded address + amount
+	input := make([]byte, 0, 68)
+	input = append(input, SelectorTransfer[:]...)
+	// left-pad address to 32 bytes
+	padded := make([]byte, 12)
+	input = append(input, padded...)
+	input = append(input, allowed.Bytes()...)
+	// amount (32 bytes of zeros)
+	input = append(input, make([]byte, 32)...)
+
+	if !kr.IsCallAllowed(token, input) {
+		t.Error("transfer to allowed recipient should be permitted")
+	}
+
+	// Same selector, different recipient
+	badInput := make([]byte, 0, 68)
+	badInput = append(badInput, SelectorTransfer[:]...)
+	badInput = append(badInput, make([]byte, 12)...)
+	badInput = append(badInput, denied.Bytes()...)
+	badInput = append(badInput, make([]byte, 32)...)
+
+	if kr.IsCallAllowed(token, badInput) {
+		t.Error("transfer to denied recipient should not be permitted")
+	}
+}
+
+func TestIsCallAllowed_NoRecipientsAllowsAny(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	anyone := common.HexToAddress("0x9999999999999999999999999999999999999999")
+
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).Transfer(nil).Build(),
+	})
+
+	input := make([]byte, 0, 68)
+	input = append(input, SelectorTransfer[:]...)
+	input = append(input, make([]byte, 12)...)
+	input = append(input, anyone.Bytes()...)
+	input = append(input, make([]byte, 32)...)
+
+	if !kr.IsCallAllowed(token, input) {
+		t.Error("transfer with no recipient restriction should allow anyone")
+	}
+}
+
+func TestIsCallAllowed_RecipientWordTooShort(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	allowed := common.HexToAddress("0x4444444444444444444444444444444444444444")
+
+	kr := NewKeyRestrictions(0).WithAllowedCalls([]CallScope{
+		NewCallScopeBuilder(token).Transfer([]common.Address{allowed}).Build(),
+	})
+
+	// Only selector, no recipient word.
+	input := SelectorTransfer[:]
+	if kr.IsCallAllowed(token, input) {
+		t.Error("input without recipient word should be denied")
+	}
+}


### PR DESCRIPTION
Port review feedback from [tempoxyz/tempo#3469](https://github.com/tempoxyz/tempo/pull/3469) to tempo-go, matching the Rust SDK and [pytempo#43](https://github.com/tempoxyz/pytempo/pull/43).

## Changes

- Add `SelectorRule` and `CallScope` types with per-selector recipient filtering
- Add `CallScopeBuilder` with `WithSelector()`, `Transfer()`, `Approve()`, `TransferWithMemo()`, `Unrestricted()`
- Add `KeyRestrictions` with private fields and getters (`IsUnrestricted`, `IsCallAllowed`, `Expiry`, `Limits`, `AllowedCalls`)
- Add call builders: `AuthorizeKey`, `SetAllowedCalls`, `RemoveAllowedCalls`, `RevokeKey`, `UpdateSpendingLimit`
- Add validation: conflicting `allowAnyCalls` + `allowedCalls`, duplicate `CallScope` targets, nil restrictions guard

## Testing

```
go test ./pkg/keychain/ -v -count=1  # 42 passed
go vet ./pkg/keychain/               # clean
go fmt ./pkg/keychain/               # clean
```

Prompted by: georgen