### PR TITLE
Add go mod verify to check target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test-coverage:
 
 # Run checks as well as unit tests
 check:
+	go mod verify
 	test -z "$$(gofmt -l .)" || (echo "Code needs formatting. Run 'make fix'" && gofmt -l . && exit 1)
 	go vet ./...
 	go test -race ./pkg/transaction ./pkg/signer ./pkg/client


### PR DESCRIPTION
Adds `go mod verify` as the first step in `make check` to detect tampered cached modules before running fmt, vet, and tests.

This hardens the supply chain by ensuring module integrity is verified locally on every check run.