### PR TITLE
docs: update CHANGELOG for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,21 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-10
+
+### Added
+
+- `CallScope`, `SelectorRule`, and `CallScopeBuilder` for scoping access keys to specific contracts, function selectors, and recipients
+- `KeyRestrictions` builder with token spending limits, call scope allowlists, and `IsCallAllowed` validation
+- `AuthorizeKey()`, `RevokeKey()`, `SetAllowedCalls()`, `RemoveAllowedCalls()`, and `UpdateSpendingLimit()` precompile call encoders
+- `AuthorizeKeyT3Selector` constant for the T3+ `authorizeKey` ABI
+- TIP-20 selector constants: `SelectorTransfer`, `SelectorApprove`, `SelectorTransferWithMemo`, `SelectorWildcard`
+- Signature type constants: `SignatureTypeSecp256k1`, `SignatureTypeP256`, `SignatureTypeWebAuthn`
+
 ### Changed
 
-- `client.GetNonce()` now accepts `*big.Int` instead of `uint64` for the nonce key parameter, enabling full 192-bit nonce key support as per the Tempo Transaction spec.
+- `client.GetNonce()` now accepts `*big.Int` instead of `uint64` for the nonce key parameter, enabling full 192-bit nonce key support as per the Tempo Transaction spec
+- Integration tests use T3 `authorizeKey` ABI by default (set `TEMPO_HARDFORK=T2` for legacy)
 
 ## [0.2.0] - 2026-01-27
 


### PR DESCRIPTION
Adds the v0.4.0 changelog entry covering keychain auth:

- `CallScope`, `SelectorRule`, `CallScopeBuilder` for scoped access keys
- `KeyRestrictions` builder with spending limits and call scope allowlists
- Precompile call encoders: `AuthorizeKey`, `RevokeKey`, `SetAllowedCalls`, `RemoveAllowedCalls`, `UpdateSpendingLimit`
- T3 `authorizeKey` ABI support
- `GetNonce()` now takes `*big.Int` for full 192-bit nonce key support

After merge, tag `v0.4.0` to trigger the release workflow.

Prompted by: rusowsky