### PR TITLE
fix(ci): use go 1.25.x/1.26.x and skip integration tests for dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.25', '1.26']
+        go-version: ['1.25.x', '1.26.x']
 
     steps:
     - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: '1.25'
+        go-version: '1.25.x'
 
     - name: Download dependencies
       run: go mod download
@@ -106,6 +106,7 @@ jobs:
     name: Integration Tests (Devnet)
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
     - name: Checkout code
@@ -116,7 +117,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: '1.25'
+        go-version: '1.25.x'
 
     - name: Download dependencies
       run: go mod download
@@ -132,6 +133,7 @@ jobs:
     name: Integration Tests (Testnet)
     runs-on: ubuntu-latest
     needs: test
+    if: ${{ github.actor != 'dependabot[bot]' }}
 
     steps:
     - name: Checkout code
@@ -142,7 +144,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
-        go-version: '1.25'
+        go-version: '1.25.x'
 
     - name: Download dependencies
       run: go mod download


### PR DESCRIPTION
Fixes CI failures on PRs #37, #39, #43:

- **go version mismatch**: `go-version: '1.25'` resolved to 1.25.8 but `go.mod` requires 1.25.9. Changed to `'1.25.x'`/`'1.26.x'` to always get the latest patch.
- **integration test panic on dependabot PRs**: devnet/testnet jobs panic because `TEMPO_RPC_URL` secret isn't available to dependabot. Added `if: github.actor != 'dependabot[bot]'` to skip those jobs.