### PR TITLE
fix: reject malleable secp256k1 signatures

### DIFF
--- a/.changelog/reject-malleable-signatures.md
+++ b/.changelog/reject-malleable-signatures.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Reject non-canonical secp256k1 signatures during transaction deserialization and address recovery, preventing transaction hash malleability via legacy `V` values and high-S signatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Security
-
-- Reject non-canonical secp256k1 signatures during transaction deserialization and address recovery, preventing transaction hash malleability via legacy `V` values and high-S signatures
-
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Security
+
+- Reject non-canonical secp256k1 signatures during transaction deserialization and address recovery, preventing transaction hash malleability via legacy `V` values and high-S signatures
+
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/pkg/signer/signer.go
+++ b/pkg/signer/signer.go
@@ -85,6 +85,8 @@ func (s *Signer) SignData(data []byte) (*Signature, error) {
 // Scalars must fit within 32 bytes (256 bits) to be valid signature components.
 const maxScalarBytes = 32
 
+var secp256k1HalfN = new(big.Int).Rsh(new(big.Int).Set(crypto.S256().Params().N), 1)
+
 // RecoverAddress recovers the address that signed the given hash with the given signature.
 func RecoverAddress(hash common.Hash, sig *Signature) (common.Address, error) {
 	if sig == nil {
@@ -101,6 +103,12 @@ func RecoverAddress(hash common.Hash, sig *Signature) (common.Address, error) {
 	sBytes := sig.S.Bytes()
 	if len(sBytes) > maxScalarBytes {
 		return common.Address{}, fmt.Errorf("%w: S exceeds %d bytes (got %d)", ErrInvalidSignature, maxScalarBytes, len(sBytes))
+	}
+	if sig.S.Cmp(secp256k1HalfN) > 0 {
+		return common.Address{}, fmt.Errorf("%w: S value is not Low-S (EIP-2)", ErrInvalidSignature)
+	}
+	if !crypto.ValidateSignatureValues(sig.YParity, sig.R, sig.S, true) {
+		return common.Address{}, fmt.Errorf("%w: invalid signature values", ErrInvalidSignature)
 	}
 
 	sigBytes := make([]byte, 65)

--- a/pkg/signer/signer_test.go
+++ b/pkg/signer/signer_test.go
@@ -120,6 +120,7 @@ func TestRecoverAddress(t *testing.T) {
 
 func TestRecoverAddress_InvalidSignatures(t *testing.T) {
 	big33Bytes := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256 requires 33 bytes
+	highS := new(big.Int).Add(new(big.Int).Set(secp256k1HalfN), big.NewInt(1))
 
 	tests := []struct {
 		name       string
@@ -168,6 +169,18 @@ func TestRecoverAddress_InvalidSignatures(t *testing.T) {
 			sig:        &Signature{R: big33Bytes, S: big33Bytes, YParity: 0},
 			wantErr:    true,
 			wantErrStr: "R exceeds",
+		},
+		{
+			name:       "high-S signature",
+			sig:        &Signature{R: big.NewInt(1), S: highS, YParity: 0},
+			wantErr:    true,
+			wantErrStr: "Low-S",
+		},
+		{
+			name:       "invalid yParity",
+			sig:        &Signature{R: big.NewInt(1), S: big.NewInt(1), YParity: 2},
+			wantErr:    true,
+			wantErrStr: "invalid signature values",
 		},
 	}
 

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -334,6 +334,22 @@ func decodeAccessList(accessListRaw []interface{}) (AccessList, error) {
 // Valid signature components must fit within 32 bytes (256 bits).
 const maxSignatureScalarBytes = 32
 
+func decodeYParity(yParityBytes []byte, context string) (uint8, error) {
+	if len(yParityBytes) == 0 {
+		return 0, nil
+	}
+	if len(yParityBytes) != 1 {
+		return 0, fmt.Errorf("invalid %s: expected single byte, got %d bytes", context, len(yParityBytes))
+	}
+
+	yParity := yParityBytes[0]
+	if yParity > 1 {
+		return 0, fmt.Errorf("invalid %s: must be 0 or 1, got %d", context, yParity)
+	}
+
+	return yParity, nil
+}
+
 // decodeSignature decodes a signature tuple [yParity, r, s].
 func decodeSignature(sigTuple []interface{}) (*signer.Signature, error) {
 	if len(sigTuple) != 3 {
@@ -345,16 +361,9 @@ func decodeSignature(sigTuple []interface{}) (*signer.Signature, error) {
 	if !ok {
 		return nil, fmt.Errorf("yParity is not bytes")
 	}
-	var yParity uint8
-	if len(yParityBytes) > 0 {
-		yParity = yParityBytes[0]
-		// Convert legacy V value (27/28) to yParity (0/1) if needed
-		if yParity >= 27 {
-			yParity -= 27
-		}
-	}
-	if yParity > 1 {
-		return nil, fmt.Errorf("invalid yParity: must be 0 or 1, got %d", yParity)
+	yParity, err := decodeYParity(yParityBytes, "yParity")
+	if err != nil {
+		return nil, err
 	}
 
 	// Field 1: r
@@ -398,14 +407,9 @@ func decodeSignatureEnvelope(envelopeBytes []byte) (*signer.SignatureEnvelope, e
 	if len(envelopeBytes) == 65 {
 		r := new(big.Int).SetBytes(envelopeBytes[0:32])
 		s := new(big.Int).SetBytes(envelopeBytes[32:64])
-		yParity := uint8(envelopeBytes[64])
-
-		// Convert legacy V value (27/28) to yParity (0/1) if needed
-		if yParity >= 27 {
-			yParity -= 27
-		}
-		if yParity > 1 {
-			return nil, fmt.Errorf("invalid yParity in signature envelope: must be 0 or 1, got %d", yParity)
+		yParity, err := decodeYParity([]byte{envelopeBytes[64]}, "yParity in signature envelope")
+		if err != nil {
+			return nil, err
 		}
 
 		return &signer.SignatureEnvelope{

--- a/pkg/transaction/golden_test.go
+++ b/pkg/transaction/golden_test.go
@@ -13,7 +13,7 @@ import (
 // This was copied over from the tempo.ts repo
 func TestTempoGoldenFormat(t *testing.T) {
 	// Format: 0x76 + RLP + senderAddress + "feefeefeefee"
-	clientTx := "0x76f87582a5bd808502cb417800825dc2dcdb9400000000000000000000000000000000000000008084deadbeefc0800b80808000c0b8417607a2e7bea757dc38093db971a7ec7537a690a698119d629b2eb6bb433315767a20aeb717b10285986bc22f0cbb7e9254a2a1f35d5c29ad5119e8b46e202ec41cd47b37BBC34fa57e9a67Ae7d0a1496edC88f04Bbfeefeefeefee"
+	clientTx := "0x76f87582a5bd808502cb417800825dc2dcdb9400000000000000000000000000000000000000008084deadbeefc0800b80808000c0b8417607a2e7bea757dc38093db971a7ec7537a690a698119d629b2eb6bb433315767a20aeb717b10285986bc22f0cbb7e9254a2a1f35d5c29ad5119e8b46e202ec401d47b37BBC34fa57e9a67Ae7d0a1496edC88f04Bbfeefeefeefee"
 
 	t.Run("Deserialize tempo.ts transaction", func(t *testing.T) {
 		tx, err := Deserialize(clientTx)

--- a/pkg/transaction/serialization_test.go
+++ b/pkg/transaction/serialization_test.go
@@ -374,6 +374,22 @@ func TestDecodeSignature(t *testing.T) {
 			want:    signer.NewSignature(max32Bytes, max32Bytes, 0),
 		},
 		{
+			name:       "legacy yParity 27 rejected",
+			r:          big.NewInt(12345).Bytes(),
+			s:          big.NewInt(67890).Bytes(),
+			yParity:    27,
+			wantErr:    true,
+			wantErrStr: "invalid yParity",
+		},
+		{
+			name:       "legacy yParity 28 rejected",
+			r:          big.NewInt(12345).Bytes(),
+			s:          big.NewInt(67890).Bytes(),
+			yParity:    28,
+			wantErr:    true,
+			wantErrStr: "invalid yParity",
+		},
+		{
 			name:       "oversized R (33 bytes)",
 			r:          big33Bytes.Bytes(),
 			s:          big.NewInt(1).Bytes(),
@@ -417,6 +433,41 @@ func TestDecodeSignature(t *testing.T) {
 			assert.Equal(t, tt.want.YParity, got.YParity)
 			assert.Equal(t, 0, got.R.Cmp(tt.want.R))
 			assert.Equal(t, 0, got.S.Cmp(tt.want.S))
+		})
+	}
+}
+
+func TestDecodeSignature_MultiByteYParityRejected(t *testing.T) {
+	input := []interface{}{
+		[]byte{0x00, 0x01},
+		big.NewInt(12345).Bytes(),
+		big.NewInt(67890).Bytes(),
+	}
+
+	got, err := decodeSignature(input)
+	assert.Error(t, err)
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "expected single byte")
+}
+
+func TestDecodeSignatureEnvelope_RejectsLegacyYParity(t *testing.T) {
+	tests := []struct {
+		name    string
+		yParity byte
+	}{
+		{name: "legacy_27", yParity: 27},
+		{name: "legacy_28", yParity: 28},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envelope, _, _ := makeSecp256k1Envelope()
+			envelope[64] = tt.yParity
+
+			decoded, err := decodeSignatureEnvelope(envelope)
+			assert.Error(t, err)
+			assert.Nil(t, decoded)
+			assert.Contains(t, err.Error(), "invalid yParity in signature envelope")
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- reject legacy `V` values during transaction signature deserialization instead of normalizing `27/28` into `0/1`
- enforce EIP-2 low-S validation in `signer.RecoverAddress` before address recovery
- add regression coverage for legacy `yParity`, multi-byte `yParity`, high-S signatures, and update the golden fixture to canonical `yParity=1`

## Brief description
This closes transaction-hash malleability caused by lax secp256k1 signature parsing and recovery. Transactions now reject non-canonical `yParity` encodings and high-S signatures that would otherwise recover the same signer under a different hash.

## Testing
- `go test ./pkg/...`
- `go test ./...` still requires `TEMPO_RPC_URL` for the existing integration package under `tests/`
