### PR TITLE
fix(transaction): accept legacy yParity {27,28} per EIP-2098 in deserialize

### DIFF
--- a/.changelog/fix-yparity-eip2098.md
+++ b/.changelog/fix-yparity-eip2098.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Accept legacy `yParity` values `{27, 28}` during transaction deserialization and normalize to `{0, 1}` per EIP-2098. Signers using the pre-EIP-155 recovery-id convention (raw secp256k1, viem `serializeSignature`, AgentCash-style EVM signers) no longer need to wrap their signatures before submitting. Serialization remains strict (only `{0, 1}` accepted on the encode path).

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -343,6 +343,14 @@ func decodeYParity(yParityBytes []byte, context string) (uint8, error) {
 	}
 
 	yParity := yParityBytes[0]
+	// EIP-2098 normalization: legacy Ethereum signers (raw secp256k1, viem
+	// serializeSignature, ecdsa libraries targeting the pre-EIP-155 recovery-id
+	// convention) emit yParity ∈ {27, 28}. EIP-2098 / EIP-1559 normalize to
+	// {0, 1} by subtracting 27. Accept either form on deserialize so clients
+	// don't have to wrap their signers; serialize.go remains strict.
+	if yParity == 27 || yParity == 28 {
+		yParity -= 27
+	}
 	if yParity > 1 {
 		return 0, fmt.Errorf("invalid %s: must be 0 or 1, got %d", context, yParity)
 	}

--- a/pkg/transaction/serialization_test.go
+++ b/pkg/transaction/serialization_test.go
@@ -374,20 +374,18 @@ func TestDecodeSignature(t *testing.T) {
 			want:    signer.NewSignature(max32Bytes, max32Bytes, 0),
 		},
 		{
-			name:       "legacy yParity 27 rejected",
-			r:          big.NewInt(12345).Bytes(),
-			s:          big.NewInt(67890).Bytes(),
-			yParity:    27,
-			wantErr:    true,
-			wantErrStr: "invalid yParity",
+			name:    "legacy yParity 27 normalized to 0 (EIP-2098)",
+			r:       big.NewInt(12345).Bytes(),
+			s:       big.NewInt(67890).Bytes(),
+			yParity: 27,
+			want:    signer.NewSignature(big.NewInt(12345), big.NewInt(67890), 0),
 		},
 		{
-			name:       "legacy yParity 28 rejected",
-			r:          big.NewInt(12345).Bytes(),
-			s:          big.NewInt(67890).Bytes(),
-			yParity:    28,
-			wantErr:    true,
-			wantErrStr: "invalid yParity",
+			name:    "legacy yParity 28 normalized to 1 (EIP-2098)",
+			r:       big.NewInt(12345).Bytes(),
+			s:       big.NewInt(67890).Bytes(),
+			yParity: 28,
+			want:    signer.NewSignature(big.NewInt(12345), big.NewInt(67890), 1),
 		},
 		{
 			name:       "oversized R (33 bytes)",
@@ -450,13 +448,14 @@ func TestDecodeSignature_MultiByteYParityRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected single byte")
 }
 
-func TestDecodeSignatureEnvelope_RejectsLegacyYParity(t *testing.T) {
+func TestDecodeSignatureEnvelope_NormalizesLegacyYParity(t *testing.T) {
 	tests := []struct {
 		name    string
 		yParity byte
+		want    uint8
 	}{
-		{name: "legacy_27", yParity: 27},
-		{name: "legacy_28", yParity: 28},
+		{name: "legacy_27_to_0", yParity: 27, want: 0},
+		{name: "legacy_28_to_1", yParity: 28, want: 1},
 	}
 
 	for _, tt := range tests {
@@ -465,9 +464,9 @@ func TestDecodeSignatureEnvelope_RejectsLegacyYParity(t *testing.T) {
 			envelope[64] = tt.yParity
 
 			decoded, err := decodeSignatureEnvelope(envelope)
-			assert.Error(t, err)
-			assert.Nil(t, decoded)
-			assert.Contains(t, err.Error(), "invalid yParity in signature envelope")
+			assert.NoError(t, err)
+			assert.NotNil(t, decoded)
+			assert.Equal(t, tt.want, decoded.Signature.YParity)
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Normalize `yParity` values `{27, 28}` to `{0, 1}` (subtract 27) inside `decodeYParity` before the upper-bound check, so transaction deserialization accepts both EIP-2098 form and the pre-EIP-155 recovery-id convention. Affects both `decodeSignature` (RLP signature tuple) and `decodeSignatureEnvelope` (raw 65-byte secp256k1 envelope).

`pkg/transaction/serialize.go` is intentionally **not** changed — serialization stays strict. We don't want to *emit* legacy values, only accept them on input.

## Why

EIP-2098 / EIP-1559 normalize yParity to `{0, 1}`, but plenty of signers in the wider Ethereum ecosystem still emit the pre-EIP-155 recovery-id form `{27, 28}`:

- `viem`'s `serializeSignature` (and various wagmi/ethers paths)
- raw secp256k1 libraries that target the legacy convention
- EVM signers ported from older Ethereum tooling

Concretely we hit this when integrating [AgentCash](https://github.com/agentcash) — a paid-API agent middleware whose EVM signer emits `yParity = 28`. Every Tempo MPP request from AgentCash failed at the gateway with:

```
[mpp] verifyTransaction: deserialize failed: failed to decode signature envelope:
invalid yParity in signature envelope: must be 0 or 1, got 28
```

\`go-ethereum\` and \`viem\` both normalize internally; \`tempo-go\` does not. Forcing every non-Tempo-CLI client to wrap its signer is a poor default. \"Be liberal in what you accept\" applies cleanly here — the on-curve recovery is the same value, just expressed in a different convention.

## Test changes

The existing `legacy yParity 27 rejected` and `legacy yParity 28 rejected` cases in `TestDecodeSignature_*` (pkg/transaction/serialization_test.go) are flipped to assert acceptance + round-trip to `{0, 1}`. `TestDecodeSignatureEnvelope_RejectsLegacyYParity` is renamed to `TestDecodeSignatureEnvelope_NormalizesLegacyYParity` with the same flip.

`go test ./pkg/transaction/...` passes.

## Out of scope

- `serialize.go:340` strict check on encode — kept as-is by design.
- Any change to malleability rejection added in #49 — that's about high-S / non-canonical signatures, orthogonal to recovery-id convention.

## Changelog

Includes a `.changelog/fix-yparity-eip2098.md` patch-level entry.