### PR TITLE
Add T5 keychain witness bindings

### DIFF
--- a/.changelog/t5-keychain-witness-bindings.md
+++ b/.changelog/t5-keychain-witness-bindings.md
@@ -1,0 +1,6 @@
+---
+github.com/tempoxyz/tempo-go: minor
+---
+
+- Add T5 AccountKeychain TIP-1053 witness bindings: `AuthorizeKeyWithWitness()`, `BurnKeyAuthorizationWitness()`, `IsKeyAuthorizationWitnessBurned()`, and matching selector constants.
+- Add T5 integration coverage for key-authorization witness burn, read, and authorize flows gated by `TEMPO_HARDFORK=T5`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- T5 AccountKeychain TIP-1053 witness bindings: `AuthorizeKeyWithWitness()`, `BurnKeyAuthorizationWitness()`, `IsKeyAuthorizationWitnessBurned()`, and matching selector constants
+- T5 integration coverage for key-authorization witness burn, read, and authorize flows gated by `TEMPO_HARDFORK=T5`
+
+### Changed
+
+- `make test`, `make check`, and `make test-coverage` now run all `./pkg/...` unit tests, including `pkg/keychain`
+
+### Follow-up
+
+- TIP20Factory `createToken(string,string,string,address,address,bytes32,string)` exists upstream, but `tempo-go` does not currently expose factory bindings to extend in this change
+
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,19 +10,6 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Added
-
-- T5 AccountKeychain TIP-1053 witness bindings: `AuthorizeKeyWithWitness()`, `BurnKeyAuthorizationWitness()`, `IsKeyAuthorizationWitnessBurned()`, and matching selector constants
-- T5 integration coverage for key-authorization witness burn, read, and authorize flows gated by `TEMPO_HARDFORK=T5`
-
-### Changed
-
-- `make test`, `make check`, and `make test-coverage` now run all `./pkg/...` unit tests, including `pkg/keychain`
-
-### Follow-up
-
-- TIP20Factory `createToken(string,string,string,address,address,bytes32,string)` exists upstream, but `tempo-go` does not currently expose factory bindings to extend in this change
-
 ## [0.4.0] - 2026-04-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ clean:
 
 # Run unit tests only (excludes integration tests)
 test:
-	go test -race ./pkg/transaction ./pkg/signer ./pkg/client
+	go test -race ./pkg/...
 
 # Run unit tests with coverage
 test-coverage:
-	go test -race -coverprofile=coverage.out ./pkg/transaction ./pkg/signer ./pkg/client
+	go test -race -coverprofile=coverage.out ./pkg/...
 	go tool cover -html=coverage.out -o cover.html
 
 # Run checks as well as unit tests
@@ -28,7 +28,7 @@ check:
 	go mod verify
 	test -z "$$(gofmt -l .)" || (echo "Code needs formatting. Run 'make fix'" && gofmt -l . && exit 1)
 	go vet ./...
-	go test -race ./pkg/transaction ./pkg/signer ./pkg/client
+	go test -race ./pkg/...
 
 # Formats code and tidies dependencies
 fix:

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ client.SendRawTransaction(context.Background(), serialized)
 | `transaction` | TempoTransaction encoding, signing, and validation | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/transaction) |
 | `client`      | RPC client for interacting with Tempo nodes        | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/client)      |
 | `signer`      | Key management and signature generation            | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/signer)      |
-| `keychain`    | Keychain-based transaction signing                 | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/keychain)    |
+| `keychain`    | Keychain-based transaction signing and witness APIs | [GoDoc](https://pkg.go.dev/github.com/tempoxyz/tempo-go/pkg/keychain)    |
 
 ## Testing
 
@@ -202,6 +202,9 @@ docker-compose up -d
 
 # Run integration tests
 make integration
+
+# Run T5 witness integration tests against a T5-capable RPC
+TEMPO_HARDFORK=T5 TEMPO_RPC_URL=<url> make integration
 
 # Stop node
 docker-compose down

--- a/pkg/keychain/calls.go
+++ b/pkg/keychain/calls.go
@@ -17,6 +17,18 @@ const SetAllowedCallsSelector = "0xf5456703"
 // removeAllowedCalls(address,address).
 const RemoveAllowedCallsSelector = "0xf3941811"
 
+// AuthorizeKeyWithWitnessSelector is the function selector for the T5
+// authorizeKey(address,uint8,KeyRestrictions,bytes32) overload.
+const AuthorizeKeyWithWitnessSelector = "0xe3c154d2"
+
+// BurnKeyAuthorizationWitnessSelector is the function selector for
+// burnKeyAuthorizationWitness(bytes32).
+const BurnKeyAuthorizationWitnessSelector = "0xcff31c46"
+
+// IsKeyAuthorizationWitnessBurnedSelector is the function selector for
+// isKeyAuthorizationWitnessBurned(address,bytes32).
+const IsKeyAuthorizationWitnessBurnedSelector = "0x8e6c7e11"
+
 // SignatureType constants matching the Rust/Solidity enum.
 const (
 	SignatureTypeSecp256k1 = 0
@@ -84,11 +96,20 @@ var keychainAddress = common.HexToAddress(AccountKeychainAddress)
 // authorizeKeyABI is the parsed ABI for authorizeKey(address,uint8,KeyRestrictions).
 var authorizeKeyABI abi.ABI
 
+// authorizeKeyWithWitnessABI is the parsed ABI for authorizeKey(address,uint8,KeyRestrictions,bytes32).
+var authorizeKeyWithWitnessABI abi.ABI
+
 // setAllowedCallsABI is the parsed ABI for setAllowedCalls(address,CallScope[]).
 var setAllowedCallsABI abi.ABI
 
 // removeAllowedCallsABI is the parsed ABI for removeAllowedCalls(address,address).
 var removeAllowedCallsABI abi.ABI
+
+// burnKeyAuthorizationWitnessABI is the parsed ABI for burnKeyAuthorizationWitness(bytes32).
+var burnKeyAuthorizationWitnessABI abi.ABI
+
+// isKeyAuthorizationWitnessBurnedABI is the parsed ABI for isKeyAuthorizationWitnessBurned(address,bytes32).
+var isKeyAuthorizationWitnessBurnedABI abi.ABI
 
 // revokeKeyABI is the parsed ABI for revokeKey(address).
 var revokeKeyABI abi.ABI
@@ -131,6 +152,33 @@ func init() {
 		]
 	}]`)
 
+	authorizeKeyWithWitnessABI = mustParseABI(`[{
+		"name": "authorizeKey",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "signatureType", "type": "uint8"},
+			{"name": "restrictions", "type": "tuple", "components": [
+				{"name": "expiry", "type": "uint64"},
+				{"name": "enforceLimits", "type": "bool"},
+				{"name": "limits", "type": "tuple[]", "components": [
+					{"name": "token", "type": "address"},
+					{"name": "amount", "type": "uint256"},
+					{"name": "period", "type": "uint64"}
+				]},
+				{"name": "allowAnyCalls", "type": "bool"},
+				{"name": "allowedCalls", "type": "tuple[]", "components": [
+					{"name": "target", "type": "address"},
+					{"name": "selectorRules", "type": "tuple[]", "components": [
+						{"name": "selector", "type": "bytes4"},
+						{"name": "recipients", "type": "address[]"}
+					]}
+				]}
+			]},
+			{"name": "witness", "type": "bytes32"}
+		]
+	}]`)
+
 	setAllowedCallsABI = mustParseABI(`[{
 		"name": "setAllowedCalls",
 		"type": "function",
@@ -155,6 +203,23 @@ func init() {
 		]
 	}]`)
 
+	burnKeyAuthorizationWitnessABI = mustParseABI(`[{
+		"name": "burnKeyAuthorizationWitness",
+		"type": "function",
+		"inputs": [
+			{"name": "witness", "type": "bytes32"}
+		]
+	}]`)
+
+	isKeyAuthorizationWitnessBurnedABI = mustParseABI(`[{
+		"name": "isKeyAuthorizationWitnessBurned",
+		"type": "function",
+		"inputs": [
+			{"name": "account", "type": "address"},
+			{"name": "witness", "type": "bytes32"}
+		]
+	}]`)
+
 	revokeKeyABI = mustParseABI(`[{
 		"name": "revokeKey",
 		"type": "function",
@@ -174,13 +239,12 @@ func init() {
 	}]`)
 }
 
-// AuthorizeKey builds an authorizeKey(address,uint8,KeyRestrictions) call.
-func AuthorizeKey(keyID common.Address, signatureType uint8, restrictions *KeyRestrictions) (Call, error) {
+func toABIKeyRestrictions(restrictions *KeyRestrictions) (abiKeyRestrictions, error) {
 	if restrictions == nil {
-		return Call{}, fmt.Errorf("restrictions must not be nil")
+		return abiKeyRestrictions{}, fmt.Errorf("restrictions must not be nil")
 	}
 	if err := restrictions.Validate(); err != nil {
-		return Call{}, fmt.Errorf("invalid restrictions: %w", err)
+		return abiKeyRestrictions{}, fmt.Errorf("invalid restrictions: %w", err)
 	}
 
 	limits := make([]abiTokenLimit, len(restrictions.limits))
@@ -192,17 +256,57 @@ func AuthorizeKey(keyID common.Address, signatureType uint8, restrictions *KeyRe
 		}
 	}
 
-	r := abiKeyRestrictions{
+	return abiKeyRestrictions{
 		Expiry:        restrictions.expiry,
 		EnforceLimits: restrictions.enforceLimits,
 		Limits:        limits,
 		AllowAnyCalls: restrictions.allowAnyCalls,
 		AllowedCalls:  toABICallScopes(restrictions.allowedCalls),
+	}, nil
+}
+
+// AuthorizeKey builds an authorizeKey(address,uint8,KeyRestrictions) call.
+func AuthorizeKey(keyID common.Address, signatureType uint8, restrictions *KeyRestrictions) (Call, error) {
+	r, err := toABIKeyRestrictions(restrictions)
+	if err != nil {
+		return Call{}, err
 	}
 
 	data, err := authorizeKeyABI.Pack("authorizeKey", keyID, signatureType, r)
 	if err != nil {
 		return Call{}, fmt.Errorf("failed to encode authorizeKey: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// AuthorizeKeyWithWitness builds an authorizeKey(address,uint8,KeyRestrictions,bytes32) call.
+func AuthorizeKeyWithWitness(keyID common.Address, signatureType uint8, restrictions *KeyRestrictions, witness common.Hash) (Call, error) {
+	r, err := toABIKeyRestrictions(restrictions)
+	if err != nil {
+		return Call{}, err
+	}
+
+	data, err := authorizeKeyWithWitnessABI.Pack("authorizeKey", keyID, signatureType, r, witness)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode authorizeKey with witness: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// BurnKeyAuthorizationWitness builds a burnKeyAuthorizationWitness(bytes32) call.
+func BurnKeyAuthorizationWitness(witness common.Hash) (Call, error) {
+	data, err := burnKeyAuthorizationWitnessABI.Pack("burnKeyAuthorizationWitness", witness)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode burnKeyAuthorizationWitness: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// IsKeyAuthorizationWitnessBurned builds an isKeyAuthorizationWitnessBurned(address,bytes32) call.
+func IsKeyAuthorizationWitnessBurned(account common.Address, witness common.Hash) (Call, error) {
+	data, err := isKeyAuthorizationWitnessBurnedABI.Pack("isKeyAuthorizationWitnessBurned", account, witness)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode isKeyAuthorizationWitnessBurned: %w", err)
 	}
 	return Call{To: keychainAddress, Data: data}, nil
 }

--- a/pkg/keychain/calls_test.go
+++ b/pkg/keychain/calls_test.go
@@ -1,6 +1,7 @@
 package keychain
 
 import (
+	"bytes"
 	"encoding/hex"
 	"math/big"
 	"testing"
@@ -8,6 +9,24 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 )
+
+func assertCallToKeychain(t *testing.T, call Call) {
+	t.Helper()
+	if call.To != keychainAddress {
+		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	}
+}
+
+func assertCallSelector(t *testing.T, call Call, selector string) {
+	t.Helper()
+	if len(call.Data) < 4 {
+		t.Fatal("calldata too short")
+	}
+	want := common.FromHex(selector)
+	if !bytes.Equal(call.Data[:4], want) {
+		t.Errorf("expected selector %s, got 0x%s", selector, hex.EncodeToString(call.Data[:4]))
+	}
+}
 
 func TestAuthorizeKey_Encodes(t *testing.T) {
 	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
@@ -17,12 +36,8 @@ func TestAuthorizeKey_Encodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.To != keychainAddress {
-		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
-	}
-	if len(call.Data) < 4 {
-		t.Fatal("calldata too short")
-	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, AuthorizeKeyT3Selector)
 }
 
 func TestAuthorizeKey_WithAllowedCalls(t *testing.T) {
@@ -46,6 +61,48 @@ func TestAuthorizeKey_NilRestrictions(t *testing.T) {
 	_, err := AuthorizeKey(keyID, SignatureTypeSecp256k1, nil)
 	if err == nil {
 		t.Error("expected error for nil restrictions")
+	}
+}
+
+func TestAuthorizeKeyWithWitness_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	witness := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	kr := NewKeyRestrictions(1000)
+
+	call, err := AuthorizeKeyWithWitness(keyID, SignatureTypeSecp256k1, kr, witness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, AuthorizeKeyWithWitnessSelector)
+}
+
+func TestAuthorizeKeyWithWitness_NilRestrictions(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	_, err := AuthorizeKeyWithWitness(keyID, SignatureTypeSecp256k1, nil, common.Hash{})
+	if err == nil {
+		t.Error("expected error for nil restrictions")
+	}
+}
+
+func TestAuthorizeKeyWithWitness_ZeroWitness(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	kr := NewKeyRestrictions(1000)
+	zeroWitness := common.Hash{}
+
+	call, err := AuthorizeKeyWithWitness(keyID, SignatureTypeSecp256k1, kr, zeroWitness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, AuthorizeKeyWithWitnessSelector)
+
+	const witnessArgOffset = 4 + 32*3
+	if len(call.Data) < witnessArgOffset+32 {
+		t.Fatal("calldata too short for witness argument")
+	}
+	if !bytes.Equal(call.Data[witnessArgOffset:witnessArgOffset+32], zeroWitness.Bytes()) {
+		t.Errorf("expected zero witness to be encoded in the witness argument word")
 	}
 }
 
@@ -88,11 +145,35 @@ func TestRevokeKey_Encodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.To != keychainAddress {
-		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, RevokeKeySelector)
+}
+
+func TestBurnKeyAuthorizationWitness_Encodes(t *testing.T) {
+	witness := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	call, err := BurnKeyAuthorizationWitness(witness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(call.Data) < 4 {
-		t.Fatal("calldata too short")
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, BurnKeyAuthorizationWitnessSelector)
+}
+
+func TestIsKeyAuthorizationWitnessBurned_Encodes(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	witness := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	call, err := IsKeyAuthorizationWitnessBurned(account, witness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, IsKeyAuthorizationWitnessBurnedSelector)
+
+	helperCalldata := EncodeIsKeyAuthorizationWitnessBurnedCalldata(account, witness)
+	if helperCalldata != "0x"+hex.EncodeToString(call.Data) {
+		t.Errorf("helper calldata mismatch: expected 0x%s, got %s", hex.EncodeToString(call.Data), helperCalldata)
 	}
 }
 
@@ -105,12 +186,8 @@ func TestSetAllowedCalls_Encodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.To != keychainAddress {
-		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
-	}
-	if len(call.Data) < 4 {
-		t.Fatal("calldata too short")
-	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, SetAllowedCallsSelector)
 }
 
 func TestSetAllowedCalls_WithRecipients(t *testing.T) {
@@ -151,12 +228,8 @@ func TestRemoveAllowedCalls_Encodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.To != keychainAddress {
-		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
-	}
-	if len(call.Data) < 4 {
-		t.Fatal("calldata too short")
-	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, RemoveAllowedCallsSelector)
 }
 
 func TestUpdateSpendingLimit_Encodes(t *testing.T) {
@@ -167,12 +240,8 @@ func TestUpdateSpendingLimit_Encodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if call.To != keychainAddress {
-		t.Errorf("expected to=%s, got %s", keychainAddress.Hex(), call.To.Hex())
-	}
-	if len(call.Data) < 4 {
-		t.Fatal("calldata too short")
-	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, UpdateSpendingLimitSelector)
 }
 
 func TestFunctionSelectors_Calls(t *testing.T) {
@@ -183,6 +252,9 @@ func TestFunctionSelectors_Calls(t *testing.T) {
 	}{
 		{"SetAllowedCalls", SetAllowedCallsSelector, "setAllowedCalls(address,(address,(bytes4,address[])[])[])"}, //nolint:lll
 		{"RemoveAllowedCalls", RemoveAllowedCallsSelector, "removeAllowedCalls(address,address)"},
+		{"AuthorizeKeyWithWitness", AuthorizeKeyWithWitnessSelector, "authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]),bytes32)"}, //nolint:lll
+		{"BurnKeyAuthorizationWitness", BurnKeyAuthorizationWitnessSelector, "burnKeyAuthorizationWitness(bytes32)"},
+		{"IsKeyAuthorizationWitnessBurned", IsKeyAuthorizationWitnessBurnedSelector, "isKeyAuthorizationWitnessBurned(address,bytes32)"}, //nolint:lll
 	}
 
 	for _, tt := range tests {

--- a/pkg/keychain/doc.go
+++ b/pkg/keychain/doc.go
@@ -4,6 +4,9 @@
 // enabling Root Keys (e.g., passkeys) to provision scoped "secondary" Access Keys
 // with expiry timestamps, per-TIP20 token spending limits, and call scope
 // restrictions (per-contract, per-selector, and per-recipient filtering).
+// T5 adds TIP-1053 witness APIs for authorizing keys with a bytes32 witness,
+// burning key-authorization witnesses, and checking whether a witness has been
+// burned for an account.
 //
 // # Keychain V2 Signature Format
 //
@@ -55,6 +58,9 @@
 // The precompile is located at address 0xAAAAAAAA00000000000000000000000000000000.
 // It provides functions for:
 //   - authorizeKey: Authorize a new access key with restrictions
+//   - authorizeKey with witness: Authorize a new access key with a TIP-1053 witness
+//   - burnKeyAuthorizationWitness: Burn a TIP-1053 witness without authorizing a key
+//   - isKeyAuthorizationWitnessBurned: Query burned witness state
 //   - revokeKey: Revoke an access key
 //   - updateSpendingLimit: Update spending limit for a token
 //   - setAllowedCalls: Set or replace call scope restrictions for a key

--- a/pkg/keychain/helpers.go
+++ b/pkg/keychain/helpers.go
@@ -33,6 +33,21 @@ func EncodeGetRemainingLimitCalldata(accountAddress, keyID, tokenAddress common.
 	return GetRemainingLimitSelector + accountPadded + keyPadded + tokenPadded
 }
 
+// EncodeIsKeyAuthorizationWitnessBurnedCalldata encodes the calldata for
+// isKeyAuthorizationWitnessBurned(address,bytes32).
+//
+// Parameters:
+//   - accountAddress: The account address
+//   - witness: The TIP-1053 key authorization witness
+//
+// Returns the hex-encoded calldata (with 0x prefix).
+func EncodeIsKeyAuthorizationWitnessBurnedCalldata(accountAddress common.Address, witness common.Hash) string {
+	accountPadded := padAddress(accountAddress)
+	witnessPadded := strings.ToLower(hex.EncodeToString(witness.Bytes()))
+
+	return IsKeyAuthorizationWitnessBurnedSelector + accountPadded + witnessPadded
+}
+
 // padAddress pads an address to 32 bytes (64 hex chars) for ABI encoding.
 func padAddress(addr common.Address) string {
 	return strings.Repeat("0", 24) + strings.ToLower(hex.EncodeToString(addr.Bytes()))

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -75,6 +75,15 @@ func isT2() bool {
 	return hardfork == "T2"
 }
 
+func isT5OrLater() bool {
+	switch hardfork {
+	case "T5", "T6":
+		return true
+	default:
+		return false
+	}
+}
+
 // testContext encapsulates common test dependencies and helpers
 type testContext struct {
 	t        *testing.T
@@ -145,6 +154,10 @@ func (tc *testContext) waitForBalance(address common.Address) {
 
 // devKeyPrivate is the well-known dev account private key used for local devnet funding.
 const devKeyPrivate = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+// farFutureKeyExpiry is valid whether a live node reports timestamps in
+// seconds or milliseconds.
+const farFutureKeyExpiry = int64(1<<63 - 1)
 
 // erc20TransferSelector is the function selector for transfer(address,uint256).
 var erc20TransferSelector = mustDecodeHex("a9059cbb")
@@ -698,7 +711,7 @@ func TestIntegration_AccessKeys(t *testing.T) {
 	t.Logf("Access key: %s", accessKey.Address().Hex())
 
 	t.Run("AuthorizeAccessKey", func(t *testing.T) {
-		calldata := buildAuthorizeKeyCalldata(accessKey.Address(), 1893456000, false)
+		calldata := buildAuthorizeKeyCalldata(accessKey.Address(), farFutureKeyExpiry, false)
 
 		eip1559Tx := types.NewTx(&types.DynamicFeeTx{
 			ChainID:   big.NewInt(tc.chainID),
@@ -793,6 +806,20 @@ func parseKeyInfoIsRevoked(resultBytes []byte) bool {
 	return false
 }
 
+// parseABIEncodedBool extracts a Solidity bool return value.
+func parseABIEncodedBool(t *testing.T, result string) bool {
+	t.Helper()
+	resultBytes, err := hex.DecodeString(strings.TrimPrefix(result, "0x"))
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, len(resultBytes), 32, "bool result too short")
+	for _, b := range resultBytes[len(resultBytes)-32:] {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // TestIntegration_KeychainSelectors tests that keychain selectors work against the precompile
 func TestIntegration_KeychainSelectors(t *testing.T) {
 	tc := newTestContext(t)
@@ -802,8 +829,7 @@ func TestIntegration_KeychainSelectors(t *testing.T) {
 	require.NoError(t, err)
 	accessKey := signer.NewSignerFromKey(accessKeyPriv)
 
-	// Use a far-future expiry (10 years from now)
-	expiry := time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+	expiry := farFutureKeyExpiry
 
 	t.Logf("Root account: %s", rootAccount.Address().Hex())
 	t.Logf("Access key: %s", accessKey.Address().Hex())
@@ -863,6 +889,81 @@ func TestIntegration_KeychainSelectors(t *testing.T) {
 	})
 }
 
+// TestIntegration_T5KeyAuthorizationWitness tests TIP-1053 witness APIs.
+func TestIntegration_T5KeyAuthorizationWitness(t *testing.T) {
+	if !isT5OrLater() {
+		t.Skip("requires TEMPO_HARDFORK=T5 or later and a T5-capable RPC")
+	}
+
+	tc := newTestContext(t)
+
+	rootAccount := tc.createAndFundSigner()
+	accessKeyPriv, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	accessKey := signer.NewSignerFromKey(accessKeyPriv)
+
+	burnWitness := crypto.Keccak256Hash([]byte("tempo-go integration burn witness"), rootAccount.Address().Bytes())
+	authWitness := crypto.Keccak256Hash([]byte("tempo-go integration auth witness"), rootAccount.Address().Bytes(), accessKey.Address().Bytes())
+
+	t.Logf("Root account: %s", rootAccount.Address().Hex())
+	t.Logf("Access key: %s", accessKey.Address().Hex())
+
+	sendKeychainCall := func(t *testing.T, call keychain.Call, msg string) {
+		t.Helper()
+		tx := tc.newTxBuilder().
+			SetNonce(tc.getNonce(rootAccount.Address())).
+			SetGas(600000).
+			AddCall(call.To, big.NewInt(0), call.Data).
+			Build()
+
+		err := transaction.SignTransaction(tx, rootAccount)
+		require.NoError(t, err)
+
+		tc.sendTxExpectSuccess(tx, msg)
+	}
+
+	isWitnessBurned := func(t *testing.T, witness common.Hash) bool {
+		t.Helper()
+		call, err := keychain.IsKeyAuthorizationWitnessBurned(rootAccount.Address(), witness)
+		require.NoError(t, err)
+
+		resp, err := tc.client.SendRequest(tc.ctx, "eth_call", map[string]interface{}{
+			"to":   call.To.Hex(),
+			"data": "0x" + hex.EncodeToString(call.Data),
+		}, "latest")
+		require.NoError(t, err)
+		require.Nil(t, resp.Error, "isKeyAuthorizationWitnessBurned eth_call failed: %v", resp.Error)
+
+		result, ok := resp.Result.(string)
+		require.True(t, ok, "expected string result")
+		return parseABIEncodedBool(t, result)
+	}
+
+	t.Run("BurnWitness", func(t *testing.T) {
+		call, err := keychain.BurnKeyAuthorizationWitness(burnWitness)
+		require.NoError(t, err)
+
+		sendKeychainCall(t, call, "burnKeyAuthorizationWitness failed")
+	})
+
+	t.Run("ReadBurnedWitnessState", func(t *testing.T) {
+		assert.True(t, isWitnessBurned(t, burnWitness), "expected burned witness to be marked burned")
+		assert.False(t, isWitnessBurned(t, authWitness), "expected unused witness to remain unburned")
+	})
+
+	t.Run("AuthorizeWithWitness", func(t *testing.T) {
+		restrictions := keychain.NewKeyRestrictions(^uint64(0))
+		call, err := keychain.AuthorizeKeyWithWitness(accessKey.Address(), keychain.SignatureTypeSecp256k1, restrictions, authWitness)
+		require.NoError(t, err)
+
+		sendKeychainCall(t, call, "authorizeKey with witness failed")
+
+		resultBytes := tc.callGetKey(rootAccount.Address(), accessKey.Address())
+		recoveredKeyId := parseKeyInfoKeyId(resultBytes)
+		assert.Equal(t, accessKey.Address(), recoveredKeyId, "getKey returned wrong keyId")
+	})
+}
+
 // TestIntegration_KeychainWithLimits tests authorizeKey with enforceLimits=true and a non-empty TokenLimit[]
 func TestIntegration_KeychainWithLimits(t *testing.T) {
 	tc := newTestContext(t)
@@ -872,7 +973,7 @@ func TestIntegration_KeychainWithLimits(t *testing.T) {
 	require.NoError(t, err)
 	accessKey := signer.NewSignerFromKey(accessKeyPriv)
 
-	expiry := time.Now().Add(10 * 365 * 24 * time.Hour).Unix()
+	expiry := farFutureKeyExpiry
 	limitAmount := new(big.Int).Mul(big.NewInt(1000), big.NewInt(1e18)) // 1000 tokens
 
 	t.Logf("Root account: %s", rootAccount.Address().Hex())


### PR DESCRIPTION
## Summary

- add T5 AccountKeychain TIP-1053 witness call encoders and selector constants
- add calldata/selector unit coverage, including nil restrictions and zero witness handling
- include `pkg/keychain` in Makefile unit/check/coverage targets via `./pkg/...`
- add T5-gated integration coverage for burn, read, and authorize-with-witness flows
- update keychain docs, README testing notes, and changelog

## Live selector note

The initially requested `0x609a0684` selector was rejected by live Tempo as `UnknownFunctionSelector(bytes4)`. That selector is for `authorizeKeyWithWitness(...)`, while the live T5 ABI exposes the overloaded `authorizeKey(address,uint8,KeyRestrictions,bytes32)` selector, `0xe3c154d2`. This PR uses the live-validated selector.

## Validation

- `go test ./pkg/...`
- `make test`
- `make test-coverage`
- `make check`
- `make build_examples`
- `make fuzz-all`
- live localnet `TEMPO_HARDFORK=T5 TEMPO_RPC_URL=http://localhost:8545 go test -v -run '^TestIntegration_T5KeyAuthorizationWitness$' -timeout=5m ./tests`
- live localnet broad non-fee-token integration suite

## Notes

Full live localnet integration was attempted. Existing fee-token-liquidity/custom-fee-token paths failed or skipped due localnet setup limitations, while the keychain/T5 witness paths passed.

TIP20Factory `createToken(string,string,string,address,address,bytes32,string)` exists upstream, but `tempo-go` does not currently expose factory bindings to extend in this change.
