### PR TITLE
fix: accept legacy recovery IDs in signature envelopes

### DIFF
--- a/.changelog/accept-legacy-recovery-id-envelope.md
+++ b/.changelog/accept-legacy-recovery-id-envelope.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Accept legacy Ethereum recovery ID values `{27, 28}` in 65-byte secp256k1 signature envelopes during transaction deserialization, normalizing them to internal `yParity` `{0, 1}`. Structured RLP signature tuples remain strict and serialization continues to emit canonical `yParity` only.

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -350,6 +350,17 @@ func decodeYParity(yParityBytes []byte, context string) (uint8, error) {
 	return yParity, nil
 }
 
+func decodeRecoveryID(recoveryID byte, context string) (uint8, error) {
+	switch recoveryID {
+	case 0, 1:
+		return recoveryID, nil
+	case 27, 28:
+		return recoveryID - 27, nil
+	default:
+		return 0, fmt.Errorf("invalid %s: must be 0, 1, 27, or 28, got %d", context, recoveryID)
+	}
+}
+
 // decodeSignature decodes a signature tuple [yParity, r, s].
 func decodeSignature(sigTuple []interface{}) (*signer.Signature, error) {
 	if len(sigTuple) != 3 {
@@ -394,7 +405,7 @@ func decodeSignature(sigTuple []interface{}) (*signer.Signature, error) {
 
 // decodeSignatureEnvelope decodes a signature envelope.
 // Per Tempo Transaction spec, signature types are detected by length and type prefix:
-// - secp256k1: raw 65 bytes (r || s || yParity) - no type prefix
+// - secp256k1: raw 65 bytes (r || s || recoveryID) - no type prefix
 // - keychain: 0x04 + user_address (20 bytes) + inner_sig (65 bytes) = 86 bytes
 // - p256: 0x01 + 129 bytes = 130 bytes
 // - webauthn: 0x02 + variable data (129-2049 bytes total)
@@ -407,7 +418,7 @@ func decodeSignatureEnvelope(envelopeBytes []byte) (*signer.SignatureEnvelope, e
 	if len(envelopeBytes) == 65 {
 		r := new(big.Int).SetBytes(envelopeBytes[0:32])
 		s := new(big.Int).SetBytes(envelopeBytes[32:64])
-		yParity, err := decodeYParity([]byte{envelopeBytes[64]}, "yParity in signature envelope")
+		yParity, err := decodeRecoveryID(envelopeBytes[64], "recovery id in signature envelope")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/transaction/serialization_test.go
+++ b/pkg/transaction/serialization_test.go
@@ -450,26 +450,68 @@ func TestDecodeSignature_MultiByteYParityRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "expected single byte")
 }
 
-func TestDecodeSignatureEnvelope_RejectsLegacyYParity(t *testing.T) {
+func TestDecodeSignatureEnvelope_NormalizesLegacyRecoveryID(t *testing.T) {
 	tests := []struct {
-		name    string
-		yParity byte
+		name       string
+		recoveryID byte
+		want       uint8
 	}{
-		{name: "legacy_27", yParity: 27},
-		{name: "legacy_28", yParity: 28},
+		{name: "canonical_0", recoveryID: 0, want: 0},
+		{name: "canonical_1", recoveryID: 1, want: 1},
+		{name: "legacy_27_to_0", recoveryID: 27, want: 0},
+		{name: "legacy_28_to_1", recoveryID: 28, want: 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			envelope, _, _ := makeSecp256k1Envelope()
-			envelope[64] = tt.yParity
+			envelope[64] = tt.recoveryID
 
 			decoded, err := decodeSignatureEnvelope(envelope)
-			assert.Error(t, err)
-			assert.Nil(t, decoded)
-			assert.Contains(t, err.Error(), "invalid yParity in signature envelope")
+			assert.NoError(t, err)
+			assert.NotNil(t, decoded)
+			assert.Equal(t, tt.want, decoded.Signature.YParity)
 		})
 	}
+}
+
+func TestDecodeSignatureEnvelope_RejectsInvalidRecoveryID(t *testing.T) {
+	envelope, _, _ := makeSecp256k1Envelope()
+	envelope[64] = 29
+
+	decoded, err := decodeSignatureEnvelope(envelope)
+	assert.Error(t, err)
+	assert.Nil(t, decoded)
+	assert.Contains(t, err.Error(), "invalid recovery id in signature envelope")
+}
+
+func TestDeserialize_NormalizesLegacyRecoveryIDEnvelope(t *testing.T) {
+	senderSgn, err := signer.NewSigner("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80")
+	assert.NoError(t, err)
+
+	tx := NewBuilder(big.NewInt(42424)).
+		SetGas(21000).
+		AddCall(common.HexToAddress("0x1234567890123456789012345678901234567890"), big.NewInt(0), []byte{}).
+		Build()
+	err = SignTransaction(tx, senderSgn)
+	assert.NoError(t, err)
+
+	serialized, err := Serialize(tx, nil)
+	assert.NoError(t, err)
+	legacySerialized := withLegacyRecoveryIDEnvelope(t, serialized)
+
+	deserialized, err := Deserialize(legacySerialized)
+	assert.NoError(t, err)
+	assert.NotNil(t, deserialized.Signature)
+	assert.Equal(t, tx.Signature.Signature.YParity, deserialized.Signature.Signature.YParity)
+
+	recovered, err := VerifySignature(deserialized)
+	assert.NoError(t, err)
+	assert.Equal(t, senderSgn.Address(), recovered)
+
+	canonicalSerialized, err := Serialize(deserialized, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, serialized, canonicalSerialized)
 }
 
 func TestDecodeSignature_InvalidTupleLength(t *testing.T) {
@@ -906,6 +948,39 @@ func encodeToHex(t *testing.T, rlpList []interface{}) string {
 	rlpBytes, err := rlp.EncodeToBytes(rlpList)
 	assert.NoError(t, err)
 	return "0x76" + hex.EncodeToString(rlpBytes)
+}
+
+func withLegacyRecoveryIDEnvelope(t *testing.T, serialized string) string {
+	t.Helper()
+
+	serializedBytes := common.FromHex(serialized)
+	if len(serializedBytes) < 2 || serializedBytes[0] != 0x76 {
+		t.Fatalf("expected serialized Tempo transaction with 0x76 prefix, got %q", serialized)
+	}
+
+	var raw []interface{}
+	if err := rlp.DecodeBytes(serializedBytes[1:], &raw); err != nil {
+		t.Fatalf("failed to decode RLP: %v", err)
+	}
+	if len(raw) != 14 && len(raw) != 15 {
+		t.Fatalf("expected signed transaction with 14 or 15 fields, got %d", len(raw))
+	}
+
+	signatureField := len(raw) - 1
+	envelope, ok := raw[signatureField].([]byte)
+	if !ok || len(envelope) != 65 {
+		t.Fatalf("expected 65-byte signature envelope in field %d, got %T length %d", signatureField, raw[signatureField], len(envelope))
+	}
+
+	legacyEnvelope := append([]byte(nil), envelope...)
+	legacyEnvelope[64] += 27
+	raw[signatureField] = legacyEnvelope
+
+	rawBytes, err := rlp.EncodeToBytes(raw)
+	if err != nil {
+		t.Fatalf("failed to encode RLP: %v", err)
+	}
+	return "0x76" + hex.EncodeToString(rawBytes)
 }
 
 func makeSecp256k1Envelope() ([]byte, *big.Int, *big.Int) {


### PR DESCRIPTION
## Summary

Accept legacy Ethereum recovery ID values `{27, 28}` only for raw 65-byte secp256k1 signature envelopes (`r || s || v`) during transaction deserialization, normalizing them to internal `yParity` `{0, 1}`.

This intentionally matches the viem-style boundary:

- raw serialized signatures may end in `0x1b/0x1c` (`27/28`)
- structured RLP signature tuples `[yParity, r, s]` remain strict and only accept `0/1`
- serialization remains canonical and only emits `0/1`

This is a narrower alternative to #51.

## Tests

- `go test ./pkg/transaction/...`
- `go test ./pkg/...`

`go test ./...` was also attempted, but the integration test package fails before running because `TEMPO_RPC_URL` is not set in this environment.
