### PR TITLE
feat: add TIP-1049 admin key support

### DIFF
--- a/pkg/keychain/calls.go
+++ b/pkg/keychain/calls.go
@@ -29,6 +29,13 @@ const BurnKeyAuthorizationWitnessSelector = "0xcff31c46"
 // isKeyAuthorizationWitnessBurned(address,bytes32).
 const IsKeyAuthorizationWitnessBurnedSelector = "0x8e6c7e11"
 
+// AuthorizeAdminKeySelector is the function selector for the T6
+// authorizeAdminKey(address,uint8,bytes32) call.
+const AuthorizeAdminKeySelector = "0x9a424307"
+
+// IsAdminKeySelector is the function selector for isAdminKey(address,address).
+const IsAdminKeySelector = "0x9009a18d"
+
 // SignatureType constants matching the Rust/Solidity enum.
 const (
 	SignatureTypeSecp256k1 = 0
@@ -110,6 +117,12 @@ var burnKeyAuthorizationWitnessABI abi.ABI
 
 // isKeyAuthorizationWitnessBurnedABI is the parsed ABI for isKeyAuthorizationWitnessBurned(address,bytes32).
 var isKeyAuthorizationWitnessBurnedABI abi.ABI
+
+// authorizeAdminKeyABI is the parsed ABI for authorizeAdminKey(address,uint8,bytes32).
+var authorizeAdminKeyABI abi.ABI
+
+// isAdminKeyABI is the parsed ABI for isAdminKey(address,address).
+var isAdminKeyABI abi.ABI
 
 // revokeKeyABI is the parsed ABI for revokeKey(address).
 var revokeKeyABI abi.ABI
@@ -220,6 +233,28 @@ func init() {
 		]
 	}]`)
 
+	authorizeAdminKeyABI = mustParseABI(`[{
+		"name": "authorizeAdminKey",
+		"type": "function",
+		"inputs": [
+			{"name": "keyId", "type": "address"},
+			{"name": "signatureType", "type": "uint8"},
+			{"name": "witness", "type": "bytes32"}
+		]
+	}]`)
+
+	isAdminKeyABI = mustParseABI(`[{
+		"name": "isAdminKey",
+		"type": "function",
+		"inputs": [
+			{"name": "account", "type": "address"},
+			{"name": "keyId", "type": "address"}
+		],
+		"outputs": [
+			{"name": "", "type": "bool"}
+		]
+	}]`)
+
 	revokeKeyABI = mustParseABI(`[{
 		"name": "revokeKey",
 		"type": "function",
@@ -289,6 +324,31 @@ func AuthorizeKeyWithWitness(keyID common.Address, signatureType uint8, restrict
 	data, err := authorizeKeyWithWitnessABI.Pack("authorizeKey", keyID, signatureType, r, witness)
 	if err != nil {
 		return Call{}, fmt.Errorf("failed to encode authorizeKey with witness: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// AuthorizeAdminKey builds an authorizeAdminKey(address,uint8,bytes32) call.
+//
+// Admin keys can manage other keys but carry no spending limits, call scopes,
+// or expiry. A zero witness (bytes32(0)) is valid.
+func AuthorizeAdminKey(keyID common.Address, signatureType uint8, witness common.Hash) (Call, error) {
+	data, err := authorizeAdminKeyABI.Pack("authorizeAdminKey", keyID, signatureType, witness)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode authorizeAdminKey: %w", err)
+	}
+	return Call{To: keychainAddress, Data: data}, nil
+}
+
+// IsAdminKey builds an isAdminKey(address,address) call.
+//
+// The call returns true when keyID is an active admin key on account, or when
+// keyID == account (the root key is implicitly admin). Parse the result with
+// ParseBoolResult.
+func IsAdminKey(account common.Address, keyID common.Address) (Call, error) {
+	data, err := isAdminKeyABI.Pack("isAdminKey", account, keyID)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode isAdminKey: %w", err)
 	}
 	return Call{To: keychainAddress, Data: data}, nil
 }

--- a/pkg/keychain/calls.go
+++ b/pkg/keychain/calls.go
@@ -331,7 +331,8 @@ func AuthorizeKeyWithWitness(keyID common.Address, signatureType uint8, restrict
 // AuthorizeAdminKey builds an authorizeAdminKey(address,uint8,bytes32) call.
 //
 // Admin keys can manage other keys but carry no spending limits, call scopes,
-// or expiry. A zero witness (bytes32(0)) is valid.
+// or expiry. A zero witness (bytes32(0)) is valid unless it has already been
+// burned for the caller's account.
 func AuthorizeAdminKey(keyID common.Address, signatureType uint8, witness common.Hash) (Call, error) {
 	data, err := authorizeAdminKeyABI.Pack("authorizeAdminKey", keyID, signatureType, witness)
 	if err != nil {

--- a/pkg/keychain/calls_test.go
+++ b/pkg/keychain/calls_test.go
@@ -28,6 +28,24 @@ func assertCallSelector(t *testing.T, call Call, selector string) {
 	}
 }
 
+// assertAddressWord verifies that a 32-byte ABI word encodes addr: the high 12
+// bytes must be zero padding and the trailing 20 bytes must equal addr.
+func assertAddressWord(t *testing.T, word []byte, addr common.Address) {
+	t.Helper()
+	if len(word) != 32 {
+		t.Fatalf("expected 32-byte word, got %d", len(word))
+	}
+	for _, b := range word[:12] {
+		if b != 0 {
+			t.Errorf("expected zero padding in address word, got 0x%s", hex.EncodeToString(word))
+			return
+		}
+	}
+	if !bytes.Equal(word[12:], addr.Bytes()) {
+		t.Errorf("expected address %s in word, got 0x%s", addr.Hex(), hex.EncodeToString(word))
+	}
+}
+
 func TestAuthorizeKey_Encodes(t *testing.T) {
 	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
 	kr := NewKeyRestrictions(1000)
@@ -286,6 +304,14 @@ func TestIsAdminKey_Encodes(t *testing.T) {
 	}
 	assertCallToKeychain(t, call)
 	assertCallSelector(t, call, IsAdminKeySelector)
+
+	// Both params are address, so the selector is identical if account/keyID
+	// are swapped. Assert the ABI word order to catch a swap.
+	if len(call.Data) < 4+32*2 {
+		t.Fatal("calldata too short for isAdminKey arguments")
+	}
+	assertAddressWord(t, call.Data[4:36], account)
+	assertAddressWord(t, call.Data[36:68], keyID)
 }
 
 func TestFunctionSelectors_Calls(t *testing.T) {

--- a/pkg/keychain/calls_test.go
+++ b/pkg/keychain/calls_test.go
@@ -244,6 +244,50 @@ func TestUpdateSpendingLimit_Encodes(t *testing.T) {
 	assertCallSelector(t, call, UpdateSpendingLimitSelector)
 }
 
+func TestAuthorizeAdminKey_Encodes(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	witness := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	call, err := AuthorizeAdminKey(keyID, SignatureTypeSecp256k1, witness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, AuthorizeAdminKeySelector)
+}
+
+func TestAuthorizeAdminKey_ZeroWitness(t *testing.T) {
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	zeroWitness := common.Hash{}
+
+	call, err := AuthorizeAdminKey(keyID, SignatureTypeSecp256k1, zeroWitness)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, AuthorizeAdminKeySelector)
+
+	const witnessArgOffset = 4 + 32*2
+	if len(call.Data) < witnessArgOffset+32 {
+		t.Fatal("calldata too short for witness argument")
+	}
+	if !bytes.Equal(call.Data[witnessArgOffset:witnessArgOffset+32], zeroWitness.Bytes()) {
+		t.Errorf("expected zero witness to be encoded in the witness argument word")
+	}
+}
+
+func TestIsAdminKey_Encodes(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	call, err := IsAdminKey(account, keyID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertCallToKeychain(t, call)
+	assertCallSelector(t, call, IsAdminKeySelector)
+}
+
 func TestFunctionSelectors_Calls(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -255,6 +299,10 @@ func TestFunctionSelectors_Calls(t *testing.T) {
 		{"AuthorizeKeyWithWitness", AuthorizeKeyWithWitnessSelector, "authorizeKey(address,uint8,(uint64,bool,(address,uint256,uint64)[],bool,(address,(bytes4,address[])[])[]),bytes32)"}, //nolint:lll
 		{"BurnKeyAuthorizationWitness", BurnKeyAuthorizationWitnessSelector, "burnKeyAuthorizationWitness(bytes32)"},
 		{"IsKeyAuthorizationWitnessBurned", IsKeyAuthorizationWitnessBurnedSelector, "isKeyAuthorizationWitnessBurned(address,bytes32)"}, //nolint:lll
+		{"AuthorizeAdminKey", AuthorizeAdminKeySelector, "authorizeAdminKey(address,uint8,bytes32)"},
+		{"IsAdminKey", IsAdminKeySelector, "isAdminKey(address,address)"},
+		{"VerifyKeychain", VerifyKeychainSelector, "verifyKeychain(address,bytes32,bytes)"},
+		{"VerifyKeychainAdmin", VerifyKeychainAdminSelector, "verifyKeychainAdmin(address,bytes32,bytes)"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/keychain/doc.go
+++ b/pkg/keychain/doc.go
@@ -7,6 +7,8 @@
 // T5 adds TIP-1053 witness APIs for authorizing keys with a bytes32 witness,
 // burning key-authorization witnesses, and checking whether a witness has been
 // burned for an account.
+// T6 adds TIP-1049 admin keys (authorizeAdminKey, isAdminKey) and the
+// SignatureVerifier keychain checks verifyKeychain and verifyKeychainAdmin.
 //
 // # Keychain V2 Signature Format
 //
@@ -59,6 +61,8 @@
 // It provides functions for:
 //   - authorizeKey: Authorize a new access key with restrictions
 //   - authorizeKey with witness: Authorize a new access key with a TIP-1053 witness
+//   - authorizeAdminKey: Authorize a new admin key (T6, no restrictions)
+//   - isAdminKey: Query whether a key is an admin key (T6)
 //   - burnKeyAuthorizationWitness: Burn a TIP-1053 witness without authorizing a key
 //   - isKeyAuthorizationWitnessBurned: Query burned witness state
 //   - revokeKey: Revoke an access key

--- a/pkg/keychain/events.go
+++ b/pkg/keychain/events.go
@@ -1,0 +1,31 @@
+package keychain
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// AdminKeyAuthorizedTopic is the topic0 hash for the T6
+// AdminKeyAuthorized(address,address) event emitted by AccountKeychain when an
+// admin key is authorized.
+const AdminKeyAuthorizedTopic = "0x493bc0240c1da6c792754dc5247d39ed76c71c99a43e16777538687f8d05e88e"
+
+// adminKeyAuthorizedTopic is the parsed topic0 hash.
+var adminKeyAuthorizedTopic = common.HexToHash(AdminKeyAuthorizedTopic)
+
+// DecodeAdminKeyAuthorized decodes an AdminKeyAuthorized log.
+//
+// Both account and publicKey are indexed, so they come from the log topics:
+// topics[0] is the event signature, topics[1] is account, topics[2] is publicKey.
+func DecodeAdminKeyAuthorized(topics []common.Hash) (account, publicKey common.Address, err error) {
+	if len(topics) != 3 {
+		return common.Address{}, common.Address{}, fmt.Errorf("expected 3 topics, got %d", len(topics))
+	}
+	if topics[0] != adminKeyAuthorizedTopic {
+		return common.Address{}, common.Address{}, fmt.Errorf("unexpected event topic: %s", topics[0].Hex())
+	}
+	account = common.BytesToAddress(topics[1].Bytes())
+	publicKey = common.BytesToAddress(topics[2].Bytes())
+	return account, publicKey, nil
+}

--- a/pkg/keychain/events.go
+++ b/pkg/keychain/events.go
@@ -16,9 +16,10 @@ var adminKeyAuthorizedTopic = common.HexToHash(AdminKeyAuthorizedTopic)
 
 // DecodeAdminKeyAuthorized decodes an AdminKeyAuthorized log.
 //
-// Both account and publicKey are indexed, so they come from the log topics:
-// topics[0] is the event signature, topics[1] is account, topics[2] is publicKey.
-func DecodeAdminKeyAuthorized(topics []common.Hash) (account, publicKey common.Address, err error) {
+// Both account and keyID are indexed: topics[0] is the event signature,
+// topics[1] is account, topics[2] is keyID. keyID is the address-derived key ID
+// (the Solidity event names it publicKey).
+func DecodeAdminKeyAuthorized(topics []common.Hash) (account, keyID common.Address, err error) {
 	if len(topics) != 3 {
 		return common.Address{}, common.Address{}, fmt.Errorf("expected 3 topics, got %d", len(topics))
 	}
@@ -26,6 +27,6 @@ func DecodeAdminKeyAuthorized(topics []common.Hash) (account, publicKey common.A
 		return common.Address{}, common.Address{}, fmt.Errorf("unexpected event topic: %s", topics[0].Hex())
 	}
 	account = common.BytesToAddress(topics[1].Bytes())
-	publicKey = common.BytesToAddress(topics[2].Bytes())
-	return account, publicKey, nil
+	keyID = common.BytesToAddress(topics[2].Bytes())
+	return account, keyID, nil
 }

--- a/pkg/keychain/events_test.go
+++ b/pkg/keychain/events_test.go
@@ -1,0 +1,56 @@
+package keychain
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestAdminKeyAuthorizedTopic(t *testing.T) {
+	hash := crypto.Keccak256([]byte("AdminKeyAuthorized(address,address)"))
+	got := "0x" + hex.EncodeToString(hash)
+	if got != AdminKeyAuthorizedTopic {
+		t.Errorf("topic mismatch: expected %s, got %s", AdminKeyAuthorizedTopic, got)
+	}
+}
+
+func TestDecodeAdminKeyAuthorized(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	publicKey := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	topics := []common.Hash{
+		adminKeyAuthorizedTopic,
+		common.BytesToHash(account.Bytes()),
+		common.BytesToHash(publicKey.Bytes()),
+	}
+
+	gotAccount, gotKey, err := DecodeAdminKeyAuthorized(topics)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotAccount != account {
+		t.Errorf("expected account %s, got %s", account.Hex(), gotAccount.Hex())
+	}
+	if gotKey != publicKey {
+		t.Errorf("expected publicKey %s, got %s", publicKey.Hex(), gotKey.Hex())
+	}
+}
+
+func TestDecodeAdminKeyAuthorized_WrongTopicCount(t *testing.T) {
+	if _, _, err := DecodeAdminKeyAuthorized([]common.Hash{adminKeyAuthorizedTopic}); err == nil {
+		t.Error("expected error for wrong topic count")
+	}
+}
+
+func TestDecodeAdminKeyAuthorized_WrongSignature(t *testing.T) {
+	topics := []common.Hash{
+		common.HexToHash("0xdeadbeef"),
+		common.Hash{},
+		common.Hash{},
+	}
+	if _, _, err := DecodeAdminKeyAuthorized(topics); err == nil {
+		t.Error("expected error for wrong event signature")
+	}
+}

--- a/pkg/keychain/events_test.go
+++ b/pkg/keychain/events_test.go
@@ -18,12 +18,12 @@ func TestAdminKeyAuthorizedTopic(t *testing.T) {
 
 func TestDecodeAdminKeyAuthorized(t *testing.T) {
 	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
-	publicKey := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	keyID := common.HexToAddress("0x1111111111111111111111111111111111111111")
 
 	topics := []common.Hash{
 		adminKeyAuthorizedTopic,
 		common.BytesToHash(account.Bytes()),
-		common.BytesToHash(publicKey.Bytes()),
+		common.BytesToHash(keyID.Bytes()),
 	}
 
 	gotAccount, gotKey, err := DecodeAdminKeyAuthorized(topics)
@@ -33,8 +33,8 @@ func TestDecodeAdminKeyAuthorized(t *testing.T) {
 	if gotAccount != account {
 		t.Errorf("expected account %s, got %s", account.Hex(), gotAccount.Hex())
 	}
-	if gotKey != publicKey {
-		t.Errorf("expected publicKey %s, got %s", publicKey.Hex(), gotKey.Hex())
+	if gotKey != keyID {
+		t.Errorf("expected keyID %s, got %s", keyID.Hex(), gotKey.Hex())
 	}
 }
 

--- a/pkg/keychain/helpers.go
+++ b/pkg/keychain/helpers.go
@@ -65,14 +65,26 @@ func ParseRemainingLimitResult(result []byte) *big.Int {
 
 // ParseBoolResult parses a 32-byte ABI-encoded bool return value.
 //
-// Any non-zero result is treated as true.
-func ParseBoolResult(result []byte) bool {
-	for _, b := range result {
+// The result must be exactly 32 bytes, with zero padding and a canonical value
+// byte (0x00 or 0x01); anything else returns an error. This is strict because
+// the result gates authorization checks.
+func ParseBoolResult(result []byte) (bool, error) {
+	if len(result) != 32 {
+		return false, fmt.Errorf("invalid ABI bool result length: expected 32, got %d", len(result))
+	}
+	for _, b := range result[:31] {
 		if b != 0 {
-			return true
+			return false, fmt.Errorf("invalid ABI bool result: non-zero padding")
 		}
 	}
-	return false
+	switch result[31] {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid ABI bool result: value byte is 0x%02x", result[31])
+	}
 }
 
 // IsKeychainSignature checks if the given signature bytes represent a Keychain signature.

--- a/pkg/keychain/helpers.go
+++ b/pkg/keychain/helpers.go
@@ -63,6 +63,18 @@ func ParseRemainingLimitResult(result []byte) *big.Int {
 	return new(big.Int).SetBytes(result)
 }
 
+// ParseBoolResult parses a 32-byte ABI-encoded bool return value.
+//
+// Any non-zero result is treated as true.
+func ParseBoolResult(result []byte) bool {
+	for _, b := range result {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // IsKeychainSignature checks if the given signature bytes represent a Keychain signature.
 func IsKeychainSignature(sig []byte) bool {
 	return len(sig) == KeychainSignatureLength && sig[0] == KeychainSignatureType

--- a/pkg/keychain/signature_verifier.go
+++ b/pkg/keychain/signature_verifier.go
@@ -63,10 +63,14 @@ func GetSignatureVerifierAddress() common.Address {
 // VerifyKeychain builds a verifyKeychain(address,bytes32,bytes) call.
 //
 // It returns true when signature over digest came from an active access key on
-// account. Only V2 keychain signatures (0x04 || root_account || inner_sig) are
-// accepted. The signature does not bind account into digest, so callers should
-// domain-separate digest (e.g. with chain ID, contract address, account).
-// Parse the result with ParseBoolResult.
+// account. Only V2 keychain signatures are accepted. The envelope embeds an
+// account that is checked against account, so cross-account replay is
+// prevented; digest should still be domain-separated (chain ID, contract,
+// purpose) against other-context replay.
+//
+// The precompile reverts on invalid/legacy/non-keychain signatures, so a false
+// result means a valid signature that failed the account/key check. Callers
+// must handle the eth_call error path, not just ParseBoolResult.
 func VerifyKeychain(account common.Address, digest common.Hash, signature []byte) (Call, error) {
 	data, err := verifyKeychainABI.Pack("verifyKeychain", account, digest, signature)
 	if err != nil {
@@ -79,9 +83,13 @@ func VerifyKeychain(account common.Address, digest common.Hash, signature []byte
 //
 // It returns true when signature over digest came from the root key or an
 // active admin access key on account. Only V2 keychain signatures are accepted.
-// The signature does not bind account into digest, so callers should
-// domain-separate digest (e.g. with chain ID, contract address, account).
-// Parse the result with ParseBoolResult.
+// The envelope embeds an account that is checked against account, so
+// cross-account replay is prevented; digest should still be domain-separated
+// (chain ID, contract, purpose) against other-context replay.
+//
+// The precompile reverts on invalid/legacy/non-keychain signatures, so a false
+// result means a valid signature that failed the account/key check. Callers
+// must handle the eth_call error path, not just ParseBoolResult.
 func VerifyKeychainAdmin(account common.Address, digest common.Hash, signature []byte) (Call, error) {
 	data, err := verifyKeychainAdminABI.Pack("verifyKeychainAdmin", account, digest, signature)
 	if err != nil {

--- a/pkg/keychain/signature_verifier.go
+++ b/pkg/keychain/signature_verifier.go
@@ -1,0 +1,91 @@
+package keychain
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// SignatureVerifierAddress is the address of the TIP-1020 SignatureVerifier precompile.
+const SignatureVerifierAddress = "0x5165300000000000000000000000000000000000"
+
+// VerifyKeychainSelector is the function selector for the T6
+// verifyKeychain(address,bytes32,bytes) call.
+const VerifyKeychainSelector = "0x6c0c731e"
+
+// VerifyKeychainAdminSelector is the function selector for the T6
+// verifyKeychainAdmin(address,bytes32,bytes) call.
+const VerifyKeychainAdminSelector = "0x5f6fc5b7"
+
+// signatureVerifierAddress is the parsed precompile address.
+var signatureVerifierAddress = common.HexToAddress(SignatureVerifierAddress)
+
+// verifyKeychainABI is the parsed ABI for verifyKeychain(address,bytes32,bytes).
+var verifyKeychainABI abi.ABI
+
+// verifyKeychainAdminABI is the parsed ABI for verifyKeychainAdmin(address,bytes32,bytes).
+var verifyKeychainAdminABI abi.ABI
+
+func init() {
+	verifyKeychainABI = mustParseABI(`[{
+		"name": "verifyKeychain",
+		"type": "function",
+		"inputs": [
+			{"name": "account", "type": "address"},
+			{"name": "digest", "type": "bytes32"},
+			{"name": "signature", "type": "bytes"}
+		],
+		"outputs": [
+			{"name": "", "type": "bool"}
+		]
+	}]`)
+
+	verifyKeychainAdminABI = mustParseABI(`[{
+		"name": "verifyKeychainAdmin",
+		"type": "function",
+		"inputs": [
+			{"name": "account", "type": "address"},
+			{"name": "digest", "type": "bytes32"},
+			{"name": "signature", "type": "bytes"}
+		],
+		"outputs": [
+			{"name": "", "type": "bool"}
+		]
+	}]`)
+}
+
+// GetSignatureVerifierAddress returns the SignatureVerifier precompile address.
+func GetSignatureVerifierAddress() common.Address {
+	return signatureVerifierAddress
+}
+
+// VerifyKeychain builds a verifyKeychain(address,bytes32,bytes) call.
+//
+// It returns true when signature over digest came from an active access key on
+// account. Only V2 keychain signatures (0x04 || root_account || inner_sig) are
+// accepted. The signature does not bind account into digest, so callers should
+// domain-separate digest (e.g. with chain ID, contract address, account).
+// Parse the result with ParseBoolResult.
+func VerifyKeychain(account common.Address, digest common.Hash, signature []byte) (Call, error) {
+	data, err := verifyKeychainABI.Pack("verifyKeychain", account, digest, signature)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode verifyKeychain: %w", err)
+	}
+	return Call{To: signatureVerifierAddress, Data: data}, nil
+}
+
+// VerifyKeychainAdmin builds a verifyKeychainAdmin(address,bytes32,bytes) call.
+//
+// It returns true when signature over digest came from the root key or an
+// active admin access key on account. Only V2 keychain signatures are accepted.
+// The signature does not bind account into digest, so callers should
+// domain-separate digest (e.g. with chain ID, contract address, account).
+// Parse the result with ParseBoolResult.
+func VerifyKeychainAdmin(account common.Address, digest common.Hash, signature []byte) (Call, error) {
+	data, err := verifyKeychainAdminABI.Pack("verifyKeychainAdmin", account, digest, signature)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode verifyKeychainAdmin: %w", err)
+	}
+	return Call{To: signatureVerifierAddress, Data: data}, nil
+}

--- a/pkg/keychain/signature_verifier_test.go
+++ b/pkg/keychain/signature_verifier_test.go
@@ -41,16 +41,34 @@ func TestVerifyKeychainAdmin_Encodes(t *testing.T) {
 func TestParseBoolResult(t *testing.T) {
 	trueWord := make([]byte, 32)
 	trueWord[31] = 1
-	if !ParseBoolResult(trueWord) {
-		t.Error("expected true for ABI-encoded true")
+	if got, err := ParseBoolResult(trueWord); err != nil || !got {
+		t.Errorf("expected (true, nil) for ABI-encoded true, got (%v, %v)", got, err)
 	}
 
 	falseWord := make([]byte, 32)
-	if ParseBoolResult(falseWord) {
-		t.Error("expected false for ABI-encoded false")
+	if got, err := ParseBoolResult(falseWord); err != nil || got {
+		t.Errorf("expected (false, nil) for ABI-encoded false, got (%v, %v)", got, err)
 	}
 
-	if ParseBoolResult(nil) {
-		t.Error("expected false for empty result")
+	// Empty / wrong-length result must be rejected.
+	if _, err := ParseBoolResult(nil); err == nil {
+		t.Error("expected error for empty result")
+	}
+	if _, err := ParseBoolResult(make([]byte, 31)); err == nil {
+		t.Error("expected error for short result")
+	}
+
+	// Non-canonical value byte must be rejected (previously read as true).
+	nonCanonical := make([]byte, 32)
+	nonCanonical[31] = 2
+	if got, err := ParseBoolResult(nonCanonical); err == nil {
+		t.Errorf("expected error for non-canonical value byte, got (%v, nil)", got)
+	}
+
+	// Non-zero padding must be rejected (previously read as true).
+	dirtyPadding := make([]byte, 32)
+	dirtyPadding[0] = 1
+	if got, err := ParseBoolResult(dirtyPadding); err == nil {
+		t.Errorf("expected error for non-zero padding, got (%v, nil)", got)
 	}
 }

--- a/pkg/keychain/signature_verifier_test.go
+++ b/pkg/keychain/signature_verifier_test.go
@@ -1,0 +1,56 @@
+package keychain
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestVerifyKeychain_Encodes(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	digest := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	sig := make([]byte, KeychainSignatureLength)
+	sig[0] = KeychainSignatureType
+
+	call, err := VerifyKeychain(account, digest, sig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != signatureVerifierAddress {
+		t.Errorf("expected to=%s, got %s", signatureVerifierAddress.Hex(), call.To.Hex())
+	}
+	assertCallSelector(t, call, VerifyKeychainSelector)
+}
+
+func TestVerifyKeychainAdmin_Encodes(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	digest := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+	sig := make([]byte, KeychainSignatureLength)
+	sig[0] = KeychainSignatureType
+
+	call, err := VerifyKeychainAdmin(account, digest, sig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != signatureVerifierAddress {
+		t.Errorf("expected to=%s, got %s", signatureVerifierAddress.Hex(), call.To.Hex())
+	}
+	assertCallSelector(t, call, VerifyKeychainAdminSelector)
+}
+
+func TestParseBoolResult(t *testing.T) {
+	trueWord := make([]byte, 32)
+	trueWord[31] = 1
+	if !ParseBoolResult(trueWord) {
+		t.Error("expected true for ABI-encoded true")
+	}
+
+	falseWord := make([]byte, 32)
+	if ParseBoolResult(falseWord) {
+		t.Error("expected false for ABI-encoded false")
+	}
+
+	if ParseBoolResult(nil) {
+		t.Error("expected false for empty result")
+	}
+}


### PR DESCRIPTION
Adds T6 (TIP-1049) admin access key support to the keychain package: `AuthorizeAdminKey` and `IsAdminKey` builders, `VerifyKeychain`/`VerifyKeychainAdmin` for the SignatureVerifier precompile, the `AdminKeyAuthorized` event decoder, and a `ParseBoolResult` helper. Tests included.

Part of OSS-397