### PR TITLE
feat: add TIP-1049 tx-embedded key authorizations

### DIFF
--- a/pkg/keychain/doc.go
+++ b/pkg/keychain/doc.go
@@ -66,4 +66,14 @@
 //   - setAllowedCalls: Set or replace call scope restrictions for a key
 //   - removeAllowedCalls: Remove call scope rules for a key+target pair
 //   - getRemainingLimit: Query remaining spending limit
+//
+// # Tx-embedded Key Authorizations (TIP-1049)
+//
+// A root or admin key can authorize another key inside a transaction instead of
+// a separate precompile call. Build a [KeyAuthorization], sign it, and attach it
+// to the transaction:
+//
+//	auth := keychain.NewKeyAuthorization(chainID, keychain.SignatureTypeSecp256k1, keyID).
+//		IntoAdmin(account)
+//	err := auth.SignAndAttach(tx, rootSigner)
 package keychain

--- a/pkg/keychain/key_authorization.go
+++ b/pkg/keychain/key_authorization.go
@@ -1,0 +1,330 @@
+package keychain
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+	"github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+// secp256k1SignatureLength is the byte length of a secp256k1 signature (r || s || v).
+const secp256k1SignatureLength = 65
+
+// KeyAuthorization is a tx-embedded key authorization (TIP-1049). It lets a root
+// or admin key authorize another key inside a transaction, rather than via a
+// separate AccountKeychain precompile call.
+//
+// Optional fields use nil/zero to mean "absent":
+//   - Expiry == 0 means the key never expires.
+//   - Limits == nil means unlimited spending; a non-nil empty slice means no spending.
+//   - AllowedCalls == nil means unrestricted calls; a non-nil empty slice means deny all.
+//   - Witness == nil means no witness; a non-nil value (including zero) attaches one.
+//   - Account == nil means the field is omitted.
+type KeyAuthorization struct {
+	ChainID      uint64
+	KeyType      uint8
+	KeyID        common.Address
+	Expiry       uint64
+	Limits       *[]TokenLimit
+	AllowedCalls *[]CallScope
+	Witness      *common.Hash
+	IsAdmin      bool
+	Account      *common.Address
+}
+
+// NewKeyAuthorization creates an unrestricted key authorization (no expiry,
+// limits, or call scopes).
+func NewKeyAuthorization(chainID uint64, keyType uint8, keyID common.Address) *KeyAuthorization {
+	return &KeyAuthorization{ChainID: chainID, KeyType: keyType, KeyID: keyID}
+}
+
+// WithExpiry sets an expiry timestamp. Zero means the key never expires.
+func (a *KeyAuthorization) WithExpiry(expiry uint64) *KeyAuthorization {
+	a.Expiry = expiry
+	return a
+}
+
+// WithLimits sets token spending limits.
+func (a *KeyAuthorization) WithLimits(limits []TokenLimit) *KeyAuthorization {
+	a.Limits = &limits
+	return a
+}
+
+// WithNoSpending denies all spending (limits enforced with an empty allowlist).
+func (a *KeyAuthorization) WithNoSpending() *KeyAuthorization {
+	empty := []TokenLimit{}
+	a.Limits = &empty
+	return a
+}
+
+// WithAllowedCalls sets call-scope restrictions.
+func (a *KeyAuthorization) WithAllowedCalls(scopes []CallScope) *KeyAuthorization {
+	a.AllowedCalls = &scopes
+	return a
+}
+
+// WithNoCalls denies all calls (scoped mode with an empty allowlist).
+func (a *KeyAuthorization) WithNoCalls() *KeyAuthorization {
+	empty := []CallScope{}
+	a.AllowedCalls = &empty
+	return a
+}
+
+// WithWitness attaches a TIP-1053 witness (zero is a valid value).
+func (a *KeyAuthorization) WithWitness(witness common.Hash) *KeyAuthorization {
+	a.Witness = &witness
+	return a
+}
+
+// IntoAdmin makes this an admin-key authorization bound to account. Admin keys
+// carry no expiry, limits, or call scopes.
+func (a *KeyAuthorization) IntoAdmin(account common.Address) *KeyAuthorization {
+	a.IsAdmin = true
+	a.Account = &account
+	return a
+}
+
+// WithAccount binds this authorization to a target account without making the
+// key an admin key.
+func (a *KeyAuthorization) WithAccount(account common.Address) *KeyAuthorization {
+	a.Account = &account
+	return a
+}
+
+// Validate checks for conflicting settings.
+func (a *KeyAuthorization) Validate() error {
+	if a.KeyType > SignatureTypeWebAuthn {
+		return fmt.Errorf("invalid key type: %d", a.KeyType)
+	}
+	if a.IsAdmin && (a.Expiry != 0 || a.Limits != nil || a.AllowedCalls != nil) {
+		return fmt.Errorf("admin keys cannot have expiry, limits, or allowed calls")
+	}
+	if a.Limits != nil {
+		for i, l := range *a.Limits {
+			if l.Amount == nil {
+				return fmt.Errorf("limits[%d].amount must not be nil", i)
+			}
+			if l.Amount.Sign() < 0 {
+				return fmt.Errorf("limits[%d].amount must be non-negative", i)
+			}
+			if l.Amount.BitLen() > 256 {
+				return fmt.Errorf("limits[%d].amount exceeds uint256", i)
+			}
+		}
+	}
+	return nil
+}
+
+// encodeFields builds the RLP field list for the unsigned authorization.
+//
+// The first three fields are always present. The trailing optional fields are
+// encoded canonically: trailing absent fields are omitted, but an absent field
+// that precedes a present one is encoded as an empty placeholder (0x80).
+func (a *KeyAuthorization) encodeFields() ([]interface{}, error) {
+	if err := a.Validate(); err != nil {
+		return nil, err
+	}
+
+	fields := []interface{}{
+		u64ToBytes(a.ChainID),
+		u64ToBytes(uint64(a.KeyType)),
+		a.KeyID.Bytes(),
+	}
+
+	var witnessVal interface{} = []byte{}
+	if a.Witness != nil {
+		witnessVal = a.Witness.Bytes()
+	}
+	var accountVal interface{} = []byte{}
+	if a.Account != nil {
+		accountVal = a.Account.Bytes()
+	}
+
+	optionals := []struct {
+		present bool
+		value   interface{}
+	}{
+		{a.Expiry != 0, u64ToBytes(a.Expiry)},
+		{a.Limits != nil, encodeTokenLimits(a.Limits)},
+		{a.AllowedCalls != nil, encodeCallScopes(a.AllowedCalls)},
+		{a.Witness != nil, witnessVal},
+		{a.IsAdmin, []byte{0x01}},
+		{a.Account != nil, accountVal},
+	}
+
+	highest := -1
+	for i, o := range optionals {
+		if o.present {
+			highest = i
+		}
+	}
+
+	for i := 0; i <= highest; i++ {
+		if optionals[i].present {
+			fields = append(fields, optionals[i].value)
+		} else {
+			// Empty placeholder (0x80) keeps later fields in position.
+			fields = append(fields, []byte{})
+		}
+	}
+
+	return fields, nil
+}
+
+// SignatureHash returns keccak256(rlp(authorization)), the hash the root or
+// admin key signs.
+func (a *KeyAuthorization) SignatureHash() (common.Hash, error) {
+	fields, err := a.encodeFields()
+	if err != nil {
+		return common.Hash{}, err
+	}
+	encoded, err := rlp.EncodeToBytes(fields)
+	if err != nil {
+		return common.Hash{}, fmt.Errorf("failed to rlp encode key authorization: %w", err)
+	}
+	return crypto.Keccak256Hash(encoded), nil
+}
+
+// Sign signs the authorization with a secp256k1 key and returns the signed
+// key authorization value to assign to tx.KeyAuthorization.
+func (a *KeyAuthorization) Sign(s *signer.Signer) ([]interface{}, error) {
+	hash, err := a.SignatureHash()
+	if err != nil {
+		return nil, err
+	}
+	sig, err := s.Sign(hash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign key authorization: %w", err)
+	}
+
+	sigBytes := make([]byte, secp256k1SignatureLength)
+	sig.R.FillBytes(sigBytes[0:32])
+	sig.S.FillBytes(sigBytes[32:64])
+	sigBytes[64] = 27 + sig.YParity
+
+	return a.BuildSigned(sigBytes)
+}
+
+// BuildSigned wraps the authorization with a pre-computed primitive signature.
+//
+// Use this for P256 or WebAuthn signatures, where signature is the raw primitive
+// signature bytes (with their type prefix). For secp256k1, pass 65 raw bytes
+// (r || s || v) or use Sign.
+func (a *KeyAuthorization) BuildSigned(signature []byte) ([]interface{}, error) {
+	if err := validatePrimitiveSignatureBytes(signature); err != nil {
+		return nil, err
+	}
+	fields, err := a.encodeFields()
+	if err != nil {
+		return nil, err
+	}
+	// Copy so later mutation of the caller's slice can't corrupt the result.
+	sigCopy := append([]byte(nil), signature...)
+	return []interface{}{fields, sigCopy}, nil
+}
+
+// validatePrimitiveSignatureBytes checks that signature is a well-formed Tempo
+// primitive signature (secp256k1, P256, or WebAuthn).
+func validatePrimitiveSignatureBytes(sig []byte) error {
+	switch {
+	case len(sig) == secp256k1SignatureLength:
+		// Canonical Rust to_bytes() uses recovery id 27/28.
+		if sig[64] != 27 && sig[64] != 28 {
+			return fmt.Errorf("invalid secp256k1 recovery id: got %d, want 27 or 28", sig[64])
+		}
+		return nil
+	case len(sig) == 130 && sig[0] == 0x01:
+		return nil // P256: 0x01 || r || s || pub_x || pub_y || pre_hash
+	case len(sig) >= 129 && len(sig) <= 2049 && sig[0] == 0x02:
+		return nil // WebAuthn: 0x02 || data || r || s || pub_x || pub_y
+	default:
+		return fmt.Errorf("invalid primitive signature bytes")
+	}
+}
+
+// SignAndAttach signs the authorization with a secp256k1 key and attaches it to
+// the transaction.
+//
+// Attach the authorization BEFORE signing the transaction: the key
+// authorization is part of the transaction's signing payload, so attaching it
+// after signing would invalidate the sender (and fee payer) signature. This
+// returns an error if the transaction is already signed.
+//
+// For admin-signed authorizations, set Account (via IntoAdmin or WithAccount).
+// For same-tx authorize-and-use, attach first, then sign the carrying
+// transaction with the newly authorized key.
+func (a *KeyAuthorization) SignAndAttach(tx *transaction.Tx, s *signer.Signer) error {
+	if tx == nil {
+		return fmt.Errorf("transaction must not be nil")
+	}
+	if tx.Signature != nil || tx.FeePayerSignature != nil {
+		return fmt.Errorf("attach key authorization before signing: it changes the transaction signing payload")
+	}
+
+	signed, err := a.Sign(s)
+	if err != nil {
+		return err
+	}
+	tx.KeyAuthorization = signed
+	return nil
+}
+
+// encodeTokenLimits encodes the limits list. A non-nil empty slice encodes as an
+// empty RLP list (0xc0), meaning "no spending allowed".
+func encodeTokenLimits(limits *[]TokenLimit) []interface{} {
+	out := make([]interface{}, 0)
+	if limits == nil {
+		return out
+	}
+	for _, l := range *limits {
+		// Period is a trailing optional: omit it when zero.
+		tuple := []interface{}{l.Token.Bytes(), u256ToBytes(l.Amount)}
+		if l.Period != 0 {
+			tuple = append(tuple, u64ToBytes(l.Period))
+		}
+		out = append(out, tuple)
+	}
+	return out
+}
+
+// encodeCallScopes encodes the call-scope list. The nested selector-rule and
+// recipient lists are always explicit (empty list means "any").
+func encodeCallScopes(scopes *[]CallScope) []interface{} {
+	out := make([]interface{}, 0)
+	if scopes == nil {
+		return out
+	}
+	for _, s := range *scopes {
+		rules := make([]interface{}, 0, len(s.SelectorRules))
+		for _, r := range s.SelectorRules {
+			recipients := make([]interface{}, 0, len(r.Recipients))
+			for _, rec := range r.Recipients {
+				recipients = append(recipients, rec.Bytes())
+			}
+			selector := r.Selector
+			rules = append(rules, []interface{}{selector[:], recipients})
+		}
+		out = append(out, []interface{}{s.Target.Bytes(), rules})
+	}
+	return out
+}
+
+// u64ToBytes returns the minimal big-endian bytes for an RLP integer (0 -> empty).
+func u64ToBytes(n uint64) []byte {
+	if n == 0 {
+		return []byte{}
+	}
+	return new(big.Int).SetUint64(n).Bytes()
+}
+
+// u256ToBytes returns the minimal big-endian bytes for an RLP integer (0/nil -> empty).
+func u256ToBytes(n *big.Int) []byte {
+	if n == nil || n.Sign() == 0 {
+		return []byte{}
+	}
+	return n.Bytes()
+}

--- a/pkg/keychain/key_authorization.go
+++ b/pkg/keychain/key_authorization.go
@@ -103,6 +103,9 @@ func (a *KeyAuthorization) Validate() error {
 	if a.IsAdmin && (a.Expiry != 0 || a.Limits != nil || a.AllowedCalls != nil) {
 		return fmt.Errorf("admin keys cannot have expiry, limits, or allowed calls")
 	}
+	if a.IsAdmin && a.Account == nil {
+		return fmt.Errorf("authorizations that create admin keys must set Account")
+	}
 	if a.Limits != nil {
 		for i, l := range *a.Limits {
 			if l.Amount == nil {

--- a/pkg/keychain/key_authorization_test.go
+++ b/pkg/keychain/key_authorization_test.go
@@ -237,6 +237,7 @@ func TestKeyAuthorization_Validate(t *testing.T) {
 	}{
 		{"invalid key type", NewKeyAuthorization(1, 9, testKeyID())},
 		{"admin with expiry", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(account).WithExpiry(1000)},
+		{"admin without account", &KeyAuthorization{ChainID: 1, KeyType: SignatureTypeSecp256k1, KeyID: testKeyID(), IsAdmin: true}},
 		{"nil limit amount", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: nil}})},
 		{"negative limit amount", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: negative}})},
 		{"limit amount over uint256", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: over256}})},

--- a/pkg/keychain/key_authorization_test.go
+++ b/pkg/keychain/key_authorization_test.go
@@ -1,0 +1,296 @@
+package keychain
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+	"github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+func testKeyID() common.Address {
+	return common.HexToAddress("0x1111111111111111111111111111111111111111")
+}
+
+func TestKeyAuthorization_UnrestrictedEncodesThreeFields(t *testing.T) {
+	auth := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID())
+
+	fields, err := auth.encodeFields()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fields) != 3 {
+		t.Fatalf("expected 3 fields for unrestricted auth, got %d", len(fields))
+	}
+}
+
+func TestKeyAuthorization_WitnessPlaceholders(t *testing.T) {
+	witness := common.HexToHash("0x5353535353535353535353535353535353535353535353535353535353535353")
+	auth := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithWitness(witness)
+
+	fields, err := auth.encodeFields()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// chain_id, key_type, key_id, expiry, limits, allowed_calls, witness
+	if len(fields) != 7 {
+		t.Fatalf("expected 7 fields, got %d", len(fields))
+	}
+	for i := 3; i <= 5; i++ {
+		b, ok := fields[i].([]byte)
+		if !ok || len(b) != 0 {
+			t.Errorf("field %d should be an empty placeholder, got %v", i, fields[i])
+		}
+	}
+	witnessBytes, ok := fields[6].([]byte)
+	if !ok || !bytes.Equal(witnessBytes, witness.Bytes()) {
+		t.Errorf("witness field mismatch: got %v", fields[6])
+	}
+}
+
+func TestKeyAuthorization_ZeroWitnessDistinctFromAbsent(t *testing.T) {
+	base := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID())
+	zeroWitness := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithWitness(common.Hash{})
+
+	baseHash, err := base.SignatureHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	zeroHash, err := zeroWitness.SignatureHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if baseHash == zeroHash {
+		t.Error("zero witness should change the signature hash")
+	}
+}
+
+func TestKeyAuthorization_AdminAndAccountBinding(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	other := common.HexToAddress("0x3333333333333333333333333333333333333333")
+
+	normal := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID())
+	admin := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(account)
+	adminOther := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(other)
+
+	normalHash, _ := normal.SignatureHash()
+	adminHash, _ := admin.SignatureHash()
+	adminOtherHash, _ := adminOther.SignatureHash()
+
+	if normalHash == adminHash {
+		t.Error("admin flag should change the signature hash")
+	}
+	if adminHash == adminOtherHash {
+		t.Error("account binding should change the signature hash")
+	}
+}
+
+func TestKeyAuthorization_IsAdminMarker(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	auth := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(account)
+
+	fields, err := auth.encodeFields()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// chain_id, key_type, key_id, expiry, limits, allowed_calls, witness, is_admin, account
+	if len(fields) != 9 {
+		t.Fatalf("expected 9 fields, got %d", len(fields))
+	}
+	adminMarker, ok := fields[7].([]byte)
+	if !ok || !bytes.Equal(adminMarker, []byte{0x01}) {
+		t.Errorf("is_admin marker should be 0x01, got %v", fields[7])
+	}
+}
+
+func TestKeyAuthorization_LimitsNoneVsEmpty(t *testing.T) {
+	none := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID())
+	noSpending := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithNoSpending()
+
+	noneFields, _ := none.encodeFields()
+	if len(noneFields) != 3 {
+		t.Fatalf("None limits should be omitted (3 fields), got %d", len(noneFields))
+	}
+
+	emptyFields, _ := noSpending.encodeFields()
+	if len(emptyFields) != 5 {
+		t.Fatalf("Some([]) limits should produce 5 fields, got %d", len(emptyFields))
+	}
+	// Field 4 is limits; must be an empty list (not an empty byte string).
+	if _, ok := emptyFields[4].([]interface{}); !ok {
+		t.Errorf("empty limits should encode as an RLP list, got %T", emptyFields[4])
+	}
+}
+
+func TestKeyAuthorization_TokenLimitPeriodOmittedWhenZero(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	noPeriod := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).
+		WithLimits([]TokenLimit{{Token: token, Amount: big.NewInt(100), Period: 0}})
+	withPeriod := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).
+		WithLimits([]TokenLimit{{Token: token, Amount: big.NewInt(100), Period: 3600}})
+
+	noPeriodFields, _ := noPeriod.encodeFields()
+	limits := noPeriodFields[4].([]interface{})
+	tuple := limits[0].([]interface{})
+	if len(tuple) != 2 {
+		t.Errorf("zero period should omit the third field, got %d fields", len(tuple))
+	}
+
+	withPeriodFields, _ := withPeriod.encodeFields()
+	limits = withPeriodFields[4].([]interface{})
+	tuple = limits[0].([]interface{})
+	if len(tuple) != 3 {
+		t.Errorf("non-zero period should include the third field, got %d fields", len(tuple))
+	}
+}
+
+func TestKeyAuthorization_SignAndRecover(t *testing.T) {
+	s, err := signer.NewSigner(rootKeyPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	auth := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithExpiry(1000)
+
+	signed, err := auth.Sign(s)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(signed) != 2 {
+		t.Fatalf("signed authorization should have 2 elements, got %d", len(signed))
+	}
+
+	sigBytes, ok := signed[1].([]byte)
+	if !ok || len(sigBytes) != secp256k1SignatureLength {
+		t.Fatalf("expected %d-byte signature, got %v", secp256k1SignatureLength, signed[1])
+	}
+
+	hash, err := auth.SignatureHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	r := new(big.Int).SetBytes(sigBytes[0:32])
+	sv := new(big.Int).SetBytes(sigBytes[32:64])
+	yParity := sigBytes[64] - 27
+	recovered, err := signer.RecoverAddress(hash, signer.NewSignature(r, sv, yParity))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if recovered != s.Address() {
+		t.Errorf("recovered %s, expected %s", recovered.Hex(), s.Address().Hex())
+	}
+}
+
+func TestKeyAuthorization_SignAndAttachRoundtrip(t *testing.T) {
+	s, err := signer.NewSigner(rootKeyPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tx := transaction.NewDefault(42431)
+	tx.MaxFeePerGas = big.NewInt(2000000000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1000000000)
+	tx.Gas = 100000
+	to := testKeyID()
+	tx.Calls = []transaction.Call{{To: &to, Value: big.NewInt(0), Data: []byte{}}}
+
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	auth := NewKeyAuthorization(42431, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(account)
+	if err := auth.SignAndAttach(tx, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tx.KeyAuthorization == nil {
+		t.Fatal("expected KeyAuthorization to be set")
+	}
+	if err := transaction.SignTransaction(tx, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	serialized, err := transaction.Serialize(tx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	decoded, err := transaction.Deserialize(serialized)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	reserialized, err := transaction.Serialize(decoded, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if serialized != reserialized {
+		t.Error("key authorization did not survive a serialize/deserialize round-trip")
+	}
+}
+
+func TestKeyAuthorization_Validate(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	negative := new(big.Int).Neg(big.NewInt(1))
+	over256 := new(big.Int).Lsh(big.NewInt(1), 256)
+
+	tests := []struct {
+		name string
+		auth *KeyAuthorization
+	}{
+		{"invalid key type", NewKeyAuthorization(1, 9, testKeyID())},
+		{"admin with expiry", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).IntoAdmin(account).WithExpiry(1000)},
+		{"nil limit amount", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: nil}})},
+		{"negative limit amount", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: negative}})},
+		{"limit amount over uint256", NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID()).WithLimits([]TokenLimit{{Token: token, Amount: over256}})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.auth.Validate(); err == nil {
+				t.Errorf("expected validation error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestKeyAuthorization_BuildSignedRejectsBadSignature(t *testing.T) {
+	auth := NewKeyAuthorization(1, SignatureTypeSecp256k1, testKeyID())
+
+	if _, err := auth.BuildSigned([]byte{0x01, 0x02}); err == nil {
+		t.Error("expected error for malformed signature bytes")
+	}
+
+	// A 65-byte secp256k1 signature with recovery id 0/1 (not 27/28) is rejected.
+	bad := make([]byte, secp256k1SignatureLength)
+	bad[64] = 1
+	if _, err := auth.BuildSigned(bad); err == nil {
+		t.Error("expected error for non-27/28 recovery id")
+	}
+
+	good := make([]byte, secp256k1SignatureLength)
+	good[64] = 27
+	if _, err := auth.BuildSigned(good); err != nil {
+		t.Errorf("unexpected error for valid 65-byte signature: %v", err)
+	}
+}
+
+func TestKeyAuthorization_SignAndAttachRejectsSignedTx(t *testing.T) {
+	s, err := signer.NewSigner(rootKeyPrivate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tx := transaction.NewDefault(42431)
+	tx.MaxFeePerGas = big.NewInt(2000000000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1000000000)
+	tx.Gas = 100000
+	to := testKeyID()
+	tx.Calls = []transaction.Call{{To: &to, Value: big.NewInt(0), Data: []byte{}}}
+
+	if err := transaction.SignTransaction(tx, s); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	auth := NewKeyAuthorization(42431, SignatureTypeSecp256k1, testKeyID())
+	if err := auth.SignAndAttach(tx, s); err == nil {
+		t.Error("expected error when attaching to an already-signed transaction")
+	}
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -84,6 +84,10 @@ func isT5OrLater() bool {
 	}
 }
 
+func isT6OrLater() bool {
+	return hardfork == "T6"
+}
+
 // testContext encapsulates common test dependencies and helpers
 type testContext struct {
 	t        *testing.T
@@ -961,6 +965,65 @@ func TestIntegration_T5KeyAuthorizationWitness(t *testing.T) {
 		resultBytes := tc.callGetKey(rootAccount.Address(), accessKey.Address())
 		recoveredKeyId := parseKeyInfoKeyId(resultBytes)
 		assert.Equal(t, accessKey.Address(), recoveredKeyId, "getKey returned wrong keyId")
+	})
+}
+
+// TestIntegration_T6KeyAuthorization tests tx-embedded key authorizations (TIP-1049).
+// A root key authorizes another key inside a transaction, instead of via a
+// separate AccountKeychain precompile call.
+func TestIntegration_T6KeyAuthorization(t *testing.T) {
+	if !isT6OrLater() {
+		t.Skip("requires TEMPO_HARDFORK=T6 and a T6-capable RPC")
+	}
+
+	tc := newTestContext(t)
+	rootAccount := tc.createAndFundSigner()
+	t.Logf("Root account: %s", rootAccount.Address().Hex())
+
+	// authorizeViaTx attaches a signed key authorization to a transaction and
+	// sends it, signed by the root key. The authorization must be attached
+	// before the transaction is signed.
+	authorizeViaTx := func(t *testing.T, auth *keychain.KeyAuthorization, msg string) {
+		t.Helper()
+		tx := tc.newTxBuilder().
+			SetNonce(tc.getNonce(rootAccount.Address())).
+			SetGas(600000).
+			AddCall(counterContract, big.NewInt(0), incrementSelector).
+			Build()
+
+		require.NoError(t, auth.SignAndAttach(tx, rootAccount))
+		require.NoError(t, transaction.SignTransaction(tx, rootAccount))
+
+		tc.sendTxExpectSuccess(tx, msg)
+		time.Sleep(3 * time.Second)
+	}
+
+	t.Run("RootAuthorizesAccessKey", func(t *testing.T) {
+		accessKeyPriv, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		accessKey := signer.NewSignerFromKey(accessKeyPriv)
+
+		auth := keychain.NewKeyAuthorization(uint64(tc.chainID), keychain.SignatureTypeSecp256k1, accessKey.Address())
+		authorizeViaTx(t, auth, "tx-embedded key authorization failed")
+
+		resultBytes := tc.callGetKey(rootAccount.Address(), accessKey.Address())
+		assert.Equal(t, accessKey.Address(), parseKeyInfoKeyId(resultBytes),
+			"key not authorized via tx-embedded authorization")
+	})
+
+	t.Run("RootAuthorizesAdminKey", func(t *testing.T) {
+		adminKeyPriv, err := crypto.GenerateKey()
+		require.NoError(t, err)
+		adminKey := signer.NewSignerFromKey(adminKeyPriv)
+
+		// Root-signed admin authorization, bound to the root account.
+		auth := keychain.NewKeyAuthorization(uint64(tc.chainID), keychain.SignatureTypeSecp256k1, adminKey.Address()).
+			IntoAdmin(rootAccount.Address())
+		authorizeViaTx(t, auth, "tx-embedded admin key authorization failed")
+
+		resultBytes := tc.callGetKey(rootAccount.Address(), adminKey.Address())
+		assert.Equal(t, adminKey.Address(), parseKeyInfoKeyId(resultBytes),
+			"admin key not authorized via tx-embedded authorization")
 	})
 }
 


### PR DESCRIPTION
Adds `KeyAuthorization` to the keychain package so a root or admin key can authorize another key inside a transaction (TIP-1049), instead of a separate precompile call. Includes builder methods, signing, RLP encoding matched to the Tempo reference, validation, unit tests, and a T6-gated integration test.

Part of OSS-397