### PR TITLE
feat: add TIP-1028 receive policies

### DIFF
--- a/pkg/receivepolicy/doc.go
+++ b/pkg/receivepolicy/doc.go
@@ -1,0 +1,26 @@
+// Package receivepolicy provides helpers for TIP-1028 receive policies.
+//
+// Receive policies let an account control which senders and which TIP-20 tokens
+// may be received. They are configured on the TIP-403 registry precompile and
+// enforced on inbound transfers and mints.
+//
+// When an inbound transfer or mint is blocked by a receive policy, the funds are
+// redirected to the ReceivePolicyGuard precompile instead of reverting. The
+// guard holds the funds and emits a TransferBlocked event carrying an
+// ABI-encoded claim receipt. The recovery authority can later claim or burn the
+// blocked funds using that receipt.
+//
+// # TIP-403 Registry
+//
+// The registry lives at 0x403C000000000000000000000000000000000000 and exposes:
+//   - setReceivePolicy: set the caller's receive policy
+//   - receivePolicy: read an account's receive policy
+//   - validateReceivePolicy: check whether an inbound transfer is allowed
+//
+// # ReceivePolicyGuard
+//
+// The guard lives at 0xB10C000000000000000000000000000000000000 and exposes:
+//   - balanceOf: blocked amount held for a receipt
+//   - claim: release blocked funds to an address
+//   - burnBlockedReceipt: burn blocked funds
+package receivepolicy

--- a/pkg/receivepolicy/doc.go
+++ b/pkg/receivepolicy/doc.go
@@ -7,8 +7,9 @@
 // When an inbound transfer or mint is blocked by a receive policy, the funds are
 // redirected to the ReceivePolicyGuard precompile instead of reverting. The
 // guard holds the funds and emits a TransferBlocked event carrying an
-// ABI-encoded claim receipt. The recovery authority can later claim or burn the
-// blocked funds using that receipt.
+// ABI-encoded claim receipt. The recovery authority can later claim the blocked
+// funds using that receipt (or, for the zero-address authority, the originator
+// can). Holders of the token's burn role can instead burn a blocked receipt.
 //
 // # TIP-403 Registry
 //

--- a/pkg/receivepolicy/events.go
+++ b/pkg/receivepolicy/events.go
@@ -36,6 +36,27 @@ func mustArg(typ string) abi.Type {
 	return t
 }
 
+// addressFromTopic extracts an address from an indexed topic, rejecting topics
+// whose high 12 bytes are non-zero rather than silently truncating them.
+func addressFromTopic(topic common.Hash, name string) (common.Address, error) {
+	for _, b := range topic[:12] {
+		if b != 0 {
+			return common.Address{}, fmt.Errorf("%s topic has non-zero high bits: %s", name, topic.Hex())
+		}
+	}
+	return common.BytesToAddress(topic.Bytes()), nil
+}
+
+// uint64FromTopic extracts a uint64 from an indexed topic, rejecting values that
+// overflow 64 bits rather than silently truncating them.
+func uint64FromTopic(topic common.Hash, name string) (uint64, error) {
+	v := topic.Big()
+	if !v.IsUint64() {
+		return 0, fmt.Errorf("%s topic overflows uint64: %s", name, topic.Hex())
+	}
+	return v.Uint64(), nil
+}
+
 func init() {
 	transferBlockedDataABI = abi.Arguments{
 		{Name: "amount", Type: mustArg("uint256")},
@@ -74,10 +95,22 @@ func DecodeTransferBlocked(topics []common.Hash, data []byte) (TransferBlockedEv
 	if err != nil {
 		return TransferBlockedEvent{}, fmt.Errorf("failed to decode TransferBlocked data: %w", err)
 	}
+	token, err := addressFromTopic(topics[1], "token")
+	if err != nil {
+		return TransferBlockedEvent{}, err
+	}
+	receiver, err := addressFromTopic(topics[2], "receiver")
+	if err != nil {
+		return TransferBlockedEvent{}, err
+	}
+	blockedNonce, err := uint64FromTopic(topics[3], "blockedNonce")
+	if err != nil {
+		return TransferBlockedEvent{}, err
+	}
 	return TransferBlockedEvent{
-		Token:          common.BytesToAddress(topics[1].Bytes()),
-		Receiver:       common.BytesToAddress(topics[2].Bytes()),
-		BlockedNonce:   topics[3].Big().Uint64(),
+		Token:          token,
+		Receiver:       receiver,
+		BlockedNonce:   blockedNonce,
 		Amount:         values[0].(*big.Int),
 		ReceiptVersion: values[1].(uint8),
 		Receipt:        values[2].([]byte),
@@ -106,8 +139,12 @@ func DecodeReceivePolicyUpdated(topics []common.Hash, data []byte) (ReceivePolic
 	if err != nil {
 		return ReceivePolicyUpdatedEvent{}, fmt.Errorf("failed to decode ReceivePolicyUpdated data: %w", err)
 	}
+	account, err := addressFromTopic(topics[1], "account")
+	if err != nil {
+		return ReceivePolicyUpdatedEvent{}, err
+	}
 	return ReceivePolicyUpdatedEvent{
-		Account:           common.BytesToAddress(topics[1].Bytes()),
+		Account:           account,
 		SenderPolicyID:    values[0].(uint64),
 		TokenFilterID:     values[1].(uint64),
 		RecoveryAuthority: values[2].(common.Address),

--- a/pkg/receivepolicy/events.go
+++ b/pkg/receivepolicy/events.go
@@ -1,0 +1,115 @@
+package receivepolicy
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// Event topic0 hashes (keccak256 of the canonical event signatures).
+const (
+	// TransferBlockedTopic is topic0 for
+	// TransferBlocked(address,address,uint64,uint256,uint8,bytes).
+	TransferBlockedTopic = "0x361d86e46fd139dc3eac4148f16b53597f0f8ddd9aba772aae0034bda5531b1c"
+	// ReceivePolicyUpdatedTopic is topic0 for
+	// ReceivePolicyUpdated(address,uint64,uint64,address).
+	ReceivePolicyUpdatedTopic = "0xf0d46e7e04f2bf4cc56ea683299f4145c2650ef690e276e069bc2b806d68b2ea"
+)
+
+var (
+	transferBlockedTopic      = common.HexToHash(TransferBlockedTopic)
+	receivePolicyUpdatedTopic = common.HexToHash(ReceivePolicyUpdatedTopic)
+)
+
+var (
+	transferBlockedDataABI      abi.Arguments
+	receivePolicyUpdatedDataABI abi.Arguments
+)
+
+func mustArg(typ string) abi.Type {
+	t, err := abi.NewType(typ, "", nil)
+	if err != nil {
+		panic(fmt.Sprintf("failed to build ABI type %q: %v", typ, err))
+	}
+	return t
+}
+
+func init() {
+	transferBlockedDataABI = abi.Arguments{
+		{Name: "amount", Type: mustArg("uint256")},
+		{Name: "receiptVersion", Type: mustArg("uint8")},
+		{Name: "receipt", Type: mustArg("bytes")},
+	}
+	receivePolicyUpdatedDataABI = abi.Arguments{
+		{Name: "senderPolicyId", Type: mustArg("uint64")},
+		{Name: "tokenFilterId", Type: mustArg("uint64")},
+		{Name: "recoveryAuthority", Type: mustArg("address")},
+	}
+}
+
+// TransferBlockedEvent is a decoded TransferBlocked log. It is emitted when an
+// inbound transfer or mint is blocked and funds are redirected to the guard.
+// Receipt is the ABI-encoded witness; decode it with DecodeClaimReceiptV1 and
+// pass it to Claim or BurnBlockedReceipt.
+type TransferBlockedEvent struct {
+	Token          common.Address // indexed
+	Receiver       common.Address // indexed
+	BlockedNonce   uint64         // indexed
+	Amount         *big.Int
+	ReceiptVersion uint8
+	Receipt        []byte
+}
+
+// DecodeTransferBlocked decodes a TransferBlocked log from its topics and data.
+func DecodeTransferBlocked(topics []common.Hash, data []byte) (TransferBlockedEvent, error) {
+	if len(topics) != 4 {
+		return TransferBlockedEvent{}, fmt.Errorf("expected 4 topics, got %d", len(topics))
+	}
+	if topics[0] != transferBlockedTopic {
+		return TransferBlockedEvent{}, fmt.Errorf("unexpected event topic: %s", topics[0].Hex())
+	}
+	values, err := transferBlockedDataABI.Unpack(data)
+	if err != nil {
+		return TransferBlockedEvent{}, fmt.Errorf("failed to decode TransferBlocked data: %w", err)
+	}
+	return TransferBlockedEvent{
+		Token:          common.BytesToAddress(topics[1].Bytes()),
+		Receiver:       common.BytesToAddress(topics[2].Bytes()),
+		BlockedNonce:   topics[3].Big().Uint64(),
+		Amount:         values[0].(*big.Int),
+		ReceiptVersion: values[1].(uint8),
+		Receipt:        values[2].([]byte),
+	}, nil
+}
+
+// ReceivePolicyUpdatedEvent is a decoded ReceivePolicyUpdated log. It is emitted
+// when an account sets or changes its receive policy.
+type ReceivePolicyUpdatedEvent struct {
+	Account           common.Address // indexed
+	SenderPolicyID    uint64
+	TokenFilterID     uint64
+	RecoveryAuthority common.Address
+}
+
+// DecodeReceivePolicyUpdated decodes a ReceivePolicyUpdated log from its topics
+// and data.
+func DecodeReceivePolicyUpdated(topics []common.Hash, data []byte) (ReceivePolicyUpdatedEvent, error) {
+	if len(topics) != 2 {
+		return ReceivePolicyUpdatedEvent{}, fmt.Errorf("expected 2 topics, got %d", len(topics))
+	}
+	if topics[0] != receivePolicyUpdatedTopic {
+		return ReceivePolicyUpdatedEvent{}, fmt.Errorf("unexpected event topic: %s", topics[0].Hex())
+	}
+	values, err := receivePolicyUpdatedDataABI.Unpack(data)
+	if err != nil {
+		return ReceivePolicyUpdatedEvent{}, fmt.Errorf("failed to decode ReceivePolicyUpdated data: %w", err)
+	}
+	return ReceivePolicyUpdatedEvent{
+		Account:           common.BytesToAddress(topics[1].Bytes()),
+		SenderPolicyID:    values[0].(uint64),
+		TokenFilterID:     values[1].(uint64),
+		RecoveryAuthority: values[2].(common.Address),
+	}, nil
+}

--- a/pkg/receivepolicy/events_test.go
+++ b/pkg/receivepolicy/events_test.go
@@ -1,0 +1,102 @@
+package receivepolicy
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func topic(sig string) string {
+	return "0x" + hex.EncodeToString(crypto.Keccak256([]byte(sig)))
+}
+
+func TestEventTopics(t *testing.T) {
+	cases := map[string]string{
+		"TransferBlocked(address,address,uint64,uint256,uint8,bytes)": TransferBlockedTopic,
+		"ReceivePolicyUpdated(address,uint64,uint64,address)":         ReceivePolicyUpdatedTopic,
+	}
+	for sig, want := range cases {
+		if got := topic(sig); got != want {
+			t.Errorf("%s: expected %s, got %s", sig, want, got)
+		}
+	}
+}
+
+func TestDecodeTransferBlocked(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	receiver := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	receipt, err := sampleReceipt().Encode()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	amount := big.NewInt(1000)
+
+	data, err := transferBlockedDataABI.Pack(amount, uint8(ReceiptVersion), receipt)
+	if err != nil {
+		t.Fatalf("pack error: %v", err)
+	}
+	topics := []common.Hash{
+		transferBlockedTopic,
+		common.BytesToHash(token.Bytes()),
+		common.BytesToHash(receiver.Bytes()),
+		common.BigToHash(big.NewInt(42)),
+	}
+
+	ev, err := DecodeTransferBlocked(topics, data)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if ev.Token != token || ev.Receiver != receiver {
+		t.Errorf("address mismatch: %+v", ev)
+	}
+	if ev.BlockedNonce != 42 {
+		t.Errorf("expected nonce 42, got %d", ev.BlockedNonce)
+	}
+	if ev.Amount.Cmp(amount) != 0 {
+		t.Errorf("expected amount %s, got %s", amount, ev.Amount)
+	}
+	if ev.ReceiptVersion != ReceiptVersion {
+		t.Errorf("expected version %d, got %d", ReceiptVersion, ev.ReceiptVersion)
+	}
+	// The carried receipt should decode back to the original.
+	if _, err := DecodeClaimReceiptV1(ev.Receipt); err != nil {
+		t.Errorf("carried receipt failed to decode: %v", err)
+	}
+}
+
+func TestDecodeTransferBlocked_WrongTopicCount(t *testing.T) {
+	if _, err := DecodeTransferBlocked([]common.Hash{transferBlockedTopic}, nil); err == nil {
+		t.Error("expected error for wrong topic count")
+	}
+}
+
+func TestDecodeReceivePolicyUpdated(t *testing.T) {
+	account := common.HexToAddress("0x5555555555555555555555555555555555555555")
+	recovery := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	data, err := receivePolicyUpdatedDataABI.Pack(uint64(7), uint64(9), recovery)
+	if err != nil {
+		t.Fatalf("pack error: %v", err)
+	}
+	topics := []common.Hash{
+		receivePolicyUpdatedTopic,
+		common.BytesToHash(account.Bytes()),
+	}
+
+	ev, err := DecodeReceivePolicyUpdated(topics, data)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if ev.Account != account {
+		t.Errorf("expected account %s, got %s", account.Hex(), ev.Account.Hex())
+	}
+	if ev.SenderPolicyID != 7 || ev.TokenFilterID != 9 {
+		t.Errorf("unexpected policy ids: %+v", ev)
+	}
+	if ev.RecoveryAuthority != recovery {
+		t.Errorf("expected recovery %s, got %s", recovery.Hex(), ev.RecoveryAuthority.Hex())
+	}
+}

--- a/pkg/receivepolicy/events_test.go
+++ b/pkg/receivepolicy/events_test.go
@@ -73,6 +73,58 @@ func TestDecodeTransferBlocked_WrongTopicCount(t *testing.T) {
 	}
 }
 
+func TestDecodeTransferBlocked_MalformedTopics(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	receiver := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	receipt, err := sampleReceipt().Encode()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	data, err := transferBlockedDataABI.Pack(big.NewInt(1000), uint8(ReceiptVersion), receipt)
+	if err != nil {
+		t.Fatalf("pack error: %v", err)
+	}
+
+	// Address topic with non-zero high bits must be rejected, not truncated.
+	dirtyAddr := common.BytesToHash(token.Bytes())
+	dirtyAddr[0] = 0xff
+	topics := []common.Hash{
+		transferBlockedTopic,
+		dirtyAddr,
+		common.BytesToHash(receiver.Bytes()),
+		common.BigToHash(big.NewInt(42)),
+	}
+	if _, err := DecodeTransferBlocked(topics, data); err == nil {
+		t.Error("expected error for token topic with non-zero high bits")
+	}
+
+	// Nonce topic that overflows uint64 must be rejected, not truncated.
+	overflow := new(big.Int).Lsh(big.NewInt(1), 65)
+	topics = []common.Hash{
+		transferBlockedTopic,
+		common.BytesToHash(token.Bytes()),
+		common.BytesToHash(receiver.Bytes()),
+		common.BigToHash(overflow),
+	}
+	if _, err := DecodeTransferBlocked(topics, data); err == nil {
+		t.Error("expected error for blockedNonce topic overflowing uint64")
+	}
+}
+
+func TestDecodeReceivePolicyUpdated_MalformedTopic(t *testing.T) {
+	recovery := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	data, err := receivePolicyUpdatedDataABI.Pack(uint64(7), uint64(9), recovery)
+	if err != nil {
+		t.Fatalf("pack error: %v", err)
+	}
+	dirtyAccount := common.BytesToHash(common.HexToAddress("0x5555555555555555555555555555555555555555").Bytes())
+	dirtyAccount[0] = 0xff
+	topics := []common.Hash{receivePolicyUpdatedTopic, dirtyAccount}
+	if _, err := DecodeReceivePolicyUpdated(topics, data); err == nil {
+		t.Error("expected error for account topic with non-zero high bits")
+	}
+}
+
 func TestDecodeReceivePolicyUpdated(t *testing.T) {
 	account := common.HexToAddress("0x5555555555555555555555555555555555555555")
 	recovery := common.HexToAddress("0x1111111111111111111111111111111111111111")

--- a/pkg/receivepolicy/guard.go
+++ b/pkg/receivepolicy/guard.go
@@ -1,0 +1,180 @@
+package receivepolicy
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// ReceivePolicyGuardAddress is the address of the ReceivePolicyGuard precompile.
+const ReceivePolicyGuardAddress = "0xB10C000000000000000000000000000000000000"
+
+// Function selectors for the ReceivePolicyGuard precompile.
+const (
+	// BalanceOfSelector is the selector for balanceOf(bytes).
+	BalanceOfSelector = "0x78415365"
+	// ClaimSelector is the selector for claim(address,bytes).
+	ClaimSelector = "0xbb1757cf"
+	// BurnBlockedReceiptSelector is the selector for burnBlockedReceipt(bytes).
+	BurnBlockedReceiptSelector = "0x96c1264c"
+)
+
+// InboundKind matches the IReceivePolicyGuard.InboundKind enum. It records
+// whether a blocked inbound operation was a transfer or a mint.
+const (
+	InboundKindTransfer = 0
+	InboundKindMint     = 1
+)
+
+// ReceiptVersion is the only supported ClaimReceiptV1 layout version.
+const ReceiptVersion = 1
+
+// ClaimReceiptV1 is the receipt witness for a single blocked inbound transfer or
+// mint. It is carried (ABI-encoded) in the TransferBlocked event and is required
+// to claim or burn the blocked funds.
+type ClaimReceiptV1 struct {
+	Version           uint8
+	Token             common.Address
+	RecoveryAuthority common.Address
+	Originator        common.Address
+	Recipient         common.Address
+	BlockedAt         uint64
+	BlockedNonce      uint64
+	BlockedReason     uint8
+	Kind              uint8
+	Memo              common.Hash
+}
+
+var receivePolicyGuardAddress = common.HexToAddress(ReceivePolicyGuardAddress)
+
+var (
+	balanceOfABI          abi.ABI
+	claimABI              abi.ABI
+	burnBlockedReceiptABI abi.ABI
+	// receiptArgs holds the ClaimReceiptV1 fields as flat top-level arguments.
+	// Every field is static, so this encodes identically to the ABI tuple
+	// (struct) encoding emitted on-chain.
+	receiptArgs abi.Arguments
+)
+
+func init() {
+	balanceOfABI = mustParseABI(`[{
+		"name": "balanceOf",
+		"type": "function",
+		"inputs": [{"name": "receipt", "type": "bytes"}],
+		"outputs": [{"name": "amount", "type": "uint256"}]
+	}]`)
+
+	claimABI = mustParseABI(`[{
+		"name": "claim",
+		"type": "function",
+		"inputs": [
+			{"name": "to", "type": "address"},
+			{"name": "receipt", "type": "bytes"}
+		]
+	}]`)
+
+	burnBlockedReceiptABI = mustParseABI(`[{
+		"name": "burnBlockedReceipt",
+		"type": "function",
+		"inputs": [{"name": "receipt", "type": "bytes"}]
+	}]`)
+
+	receiptArgs = abi.Arguments{
+		{Name: "version", Type: mustArg("uint8")},
+		{Name: "token", Type: mustArg("address")},
+		{Name: "recoveryAuthority", Type: mustArg("address")},
+		{Name: "originator", Type: mustArg("address")},
+		{Name: "recipient", Type: mustArg("address")},
+		{Name: "blockedAt", Type: mustArg("uint64")},
+		{Name: "blockedNonce", Type: mustArg("uint64")},
+		{Name: "blockedReason", Type: mustArg("uint8")},
+		{Name: "kind", Type: mustArg("uint8")},
+		{Name: "memo", Type: mustArg("bytes32")},
+	}
+}
+
+// GetReceivePolicyGuardAddress returns the ReceivePolicyGuard precompile address.
+func GetReceivePolicyGuardAddress() common.Address {
+	return receivePolicyGuardAddress
+}
+
+// Encode ABI-encodes the receipt into the witness bytes accepted by the guard.
+func (r ClaimReceiptV1) Encode() ([]byte, error) {
+	var memo [32]byte
+	copy(memo[:], r.Memo.Bytes())
+	data, err := receiptArgs.Pack(
+		r.Version, r.Token, r.RecoveryAuthority, r.Originator, r.Recipient,
+		r.BlockedAt, r.BlockedNonce, r.BlockedReason, r.Kind, memo,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode claim receipt: %w", err)
+	}
+	return data, nil
+}
+
+// DecodeClaimReceiptV1 decodes an ABI-encoded receipt witness. All fields are
+// static, so a valid V1 receipt is exactly 320 bytes (10 * 32).
+func DecodeClaimReceiptV1(data []byte) (ClaimReceiptV1, error) {
+	if len(data) != 10*32 {
+		return ClaimReceiptV1{}, fmt.Errorf("invalid receipt length: expected 320, got %d", len(data))
+	}
+	values, err := receiptArgs.Unpack(data)
+	if err != nil {
+		return ClaimReceiptV1{}, fmt.Errorf("failed to decode claim receipt: %w", err)
+	}
+	memo := values[9].([32]byte)
+	receipt := ClaimReceiptV1{
+		Version:           values[0].(uint8),
+		Token:             values[1].(common.Address),
+		RecoveryAuthority: values[2].(common.Address),
+		Originator:        values[3].(common.Address),
+		Recipient:         values[4].(common.Address),
+		BlockedAt:         values[5].(uint64),
+		BlockedNonce:      values[6].(uint64),
+		BlockedReason:     values[7].(uint8),
+		Kind:              values[8].(uint8),
+		Memo:              common.BytesToHash(memo[:]),
+	}
+	if receipt.Version != ReceiptVersion {
+		return ClaimReceiptV1{}, fmt.Errorf("unsupported receipt version: %d", receipt.Version)
+	}
+	return receipt, nil
+}
+
+// BalanceOf builds a balanceOf(bytes) call. It returns the blocked amount held
+// by the guard for the given receipt. Parse the result with ParseBalanceResult.
+func BalanceOf(receipt []byte) (Call, error) {
+	data, err := balanceOfABI.Pack("balanceOf", receipt)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode balanceOf: %w", err)
+	}
+	return Call{To: receivePolicyGuardAddress, Data: data}, nil
+}
+
+// ParseBalanceResult parses the 32-byte uint256 result of a balanceOf call.
+func ParseBalanceResult(result []byte) *big.Int {
+	return new(big.Int).SetBytes(result)
+}
+
+// Claim builds a claim(address,bytes) call. It releases the blocked funds for
+// receipt to the address to. Only the receipt's recovery authority may claim.
+func Claim(to common.Address, receipt []byte) (Call, error) {
+	data, err := claimABI.Pack("claim", to, receipt)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode claim: %w", err)
+	}
+	return Call{To: receivePolicyGuardAddress, Data: data}, nil
+}
+
+// BurnBlockedReceipt builds a burnBlockedReceipt(bytes) call. It burns the
+// blocked funds for receipt.
+func BurnBlockedReceipt(receipt []byte) (Call, error) {
+	data, err := burnBlockedReceiptABI.Pack("burnBlockedReceipt", receipt)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode burnBlockedReceipt: %w", err)
+	}
+	return Call{To: receivePolicyGuardAddress, Data: data}, nil
+}

--- a/pkg/receivepolicy/guard.go
+++ b/pkg/receivepolicy/guard.go
@@ -56,8 +56,12 @@ var (
 	claimABI              abi.ABI
 	burnBlockedReceiptABI abi.ABI
 	// receiptArgs holds the ClaimReceiptV1 fields as flat top-level arguments.
-	// Every field is static, so this encodes identically to the ABI tuple
-	// (struct) encoding emitted on-chain.
+	// This encodes identically to the ABI tuple (struct) encoding emitted
+	// on-chain only because of the all-static V1 layout: with no dynamic field
+	// (bytes/string/dynamic array) there is no leading offset word, so flat
+	// args and a single tuple arg produce the same bytes. A future receipt
+	// version that adds a dynamic field would diverge and need a real tuple.
+	// TestReceiptEncodingMatchesTuple pins this equivalence.
 	receiptArgs abi.Arguments
 )
 
@@ -104,7 +108,18 @@ func GetReceivePolicyGuardAddress() common.Address {
 }
 
 // Encode ABI-encodes the receipt into the witness bytes accepted by the guard.
+// It validates the V1 invariants first (version and enum ranges) so callers
+// fail fast instead of producing a witness the precompile would reject.
 func (r ClaimReceiptV1) Encode() ([]byte, error) {
+	if r.Version != ReceiptVersion {
+		return nil, fmt.Errorf("unsupported receipt version: %d", r.Version)
+	}
+	if r.BlockedReason > BlockedReasonReceivePolicy {
+		return nil, fmt.Errorf("invalid blocked reason: %d", r.BlockedReason)
+	}
+	if r.Kind > InboundKindMint {
+		return nil, fmt.Errorf("invalid inbound kind: %d", r.Kind)
+	}
 	var memo [32]byte
 	copy(memo[:], r.Memo.Bytes())
 	data, err := receiptArgs.Pack(
@@ -156,9 +171,21 @@ func BalanceOf(receipt []byte) (Call, error) {
 	return Call{To: receivePolicyGuardAddress, Data: data}, nil
 }
 
-// ParseBalanceResult parses the 32-byte uint256 result of a balanceOf call.
-func ParseBalanceResult(result []byte) *big.Int {
-	return new(big.Int).SetBytes(result)
+// ParseBalanceResult ABI-decodes the uint256 result of a balanceOf call. The
+// result must be exactly one 32-byte word; ABI unpacking alone would accept
+// trailing garbage for this single static output.
+func ParseBalanceResult(result []byte) (*big.Int, error) {
+	if len(result) != 32 {
+		return nil, fmt.Errorf("invalid balanceOf result length: expected 32, got %d", len(result))
+	}
+	values, err := balanceOfABI.Unpack("balanceOf", result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode balanceOf result: %w", err)
+	}
+	if len(values) != 1 {
+		return nil, fmt.Errorf("expected 1 return value, got %d", len(values))
+	}
+	return values[0].(*big.Int), nil
 }
 
 // Claim builds a claim(address,bytes) call. It releases the blocked funds for

--- a/pkg/receivepolicy/guard.go
+++ b/pkg/receivepolicy/guard.go
@@ -35,8 +35,10 @@ const ReceiptVersion = 1
 // mint. It is carried (ABI-encoded) in the TransferBlocked event and is required
 // to claim or burn the blocked funds.
 type ClaimReceiptV1 struct {
-	Version           uint8
-	Token             common.Address
+	Version uint8
+	Token   common.Address
+	// RecoveryAuthority may claim the funds; the zero address means the
+	// originator is the claimer.
 	RecoveryAuthority common.Address
 	Originator        common.Address
 	Recipient         common.Address
@@ -160,7 +162,8 @@ func ParseBalanceResult(result []byte) *big.Int {
 }
 
 // Claim builds a claim(address,bytes) call. It releases the blocked funds for
-// receipt to the address to. Only the receipt's recovery authority may claim.
+// receipt to the address to. Only the receipt's recovery authority may claim;
+// when that authority is the zero address, only the originator may claim.
 func Claim(to common.Address, receipt []byte) (Call, error) {
 	data, err := claimABI.Pack("claim", to, receipt)
 	if err != nil {
@@ -170,7 +173,8 @@ func Claim(to common.Address, receipt []byte) (Call, error) {
 }
 
 // BurnBlockedReceipt builds a burnBlockedReceipt(bytes) call. It burns the
-// blocked funds for receipt.
+// blocked funds for receipt. The caller must hold BURN_BLOCKED_ROLE for the
+// receipt's token.
 func BurnBlockedReceipt(receipt []byte) (Call, error) {
 	data, err := burnBlockedReceiptABI.Pack("burnBlockedReceipt", receipt)
 	if err != nil {

--- a/pkg/receivepolicy/guard_test.go
+++ b/pkg/receivepolicy/guard_test.go
@@ -1,10 +1,12 @@
 package receivepolicy
 
 import (
+	"bytes"
 	"encoding/hex"
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -99,7 +101,104 @@ func TestDecodeClaimReceiptV1_Invalid(t *testing.T) {
 
 func TestParseBalanceResult(t *testing.T) {
 	encoded := common.BigToHash(big.NewInt(123456)).Bytes()
-	if got := ParseBalanceResult(encoded); got.Cmp(big.NewInt(123456)) != 0 {
+	got, err := ParseBalanceResult(encoded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Cmp(big.NewInt(123456)) != 0 {
 		t.Errorf("expected 123456, got %s", got)
+	}
+}
+
+func TestParseBalanceResult_Invalid(t *testing.T) {
+	// Short, empty, and oversized (trailing garbage) results must all error
+	// instead of being silently accepted.
+	for _, tc := range []struct {
+		name string
+		data []byte
+	}{
+		{"short", []byte{0x01, 0x02}},
+		{"empty", nil},
+		{"trailing garbage", append(common.BigToHash(big.NewInt(1)).Bytes(), 0xff)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseBalanceResult(tc.data); err == nil {
+				t.Errorf("expected error for %s balance result", tc.name)
+			}
+		})
+	}
+}
+
+func TestEncode_Invalid(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		mutate func(*ClaimReceiptV1)
+	}{
+		{"bad version", func(r *ClaimReceiptV1) { r.Version = 2 }},
+		{"bad blocked reason", func(r *ClaimReceiptV1) { r.BlockedReason = 99 }},
+		{"bad kind", func(r *ClaimReceiptV1) { r.Kind = 99 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := sampleReceipt()
+			tc.mutate(&r)
+			if _, err := r.Encode(); err == nil {
+				t.Errorf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+// TestReceiptEncodingMatchesTuple pins the equivalence between the flat-args
+// encoding used by Encode and the canonical single-tuple (struct) encoding the
+// precompile produces on-chain. This holds only because every V1 field is
+// static; if a future version adds a dynamic field this test will fail and the
+// flat encoding will need to become a real tuple.
+func TestReceiptEncodingMatchesTuple(t *testing.T) {
+	r := sampleReceipt()
+	flat, err := r.Encode()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+
+	tupleType, err := abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+		{Name: "version", Type: "uint8"},
+		{Name: "token", Type: "address"},
+		{Name: "recoveryAuthority", Type: "address"},
+		{Name: "originator", Type: "address"},
+		{Name: "recipient", Type: "address"},
+		{Name: "blockedAt", Type: "uint64"},
+		{Name: "blockedNonce", Type: "uint64"},
+		{Name: "blockedReason", Type: "uint8"},
+		{Name: "kind", Type: "uint8"},
+		{Name: "memo", Type: "bytes32"},
+	})
+	if err != nil {
+		t.Fatalf("tuple type error: %v", err)
+	}
+	tupleArgs := abi.Arguments{{Name: "receipt", Type: tupleType}}
+
+	var memo [32]byte
+	copy(memo[:], r.Memo.Bytes())
+	tuple, err := tupleArgs.Pack(struct {
+		Version           uint8
+		Token             common.Address
+		RecoveryAuthority common.Address
+		Originator        common.Address
+		Recipient         common.Address
+		BlockedAt         uint64
+		BlockedNonce      uint64
+		BlockedReason     uint8
+		Kind              uint8
+		Memo              [32]byte
+	}{
+		r.Version, r.Token, r.RecoveryAuthority, r.Originator, r.Recipient,
+		r.BlockedAt, r.BlockedNonce, r.BlockedReason, r.Kind, memo,
+	})
+	if err != nil {
+		t.Fatalf("tuple pack error: %v", err)
+	}
+
+	if !bytes.Equal(flat, tuple) {
+		t.Errorf("flat and tuple encodings differ:\n flat:  %x\n tuple: %x", flat, tuple)
 	}
 }

--- a/pkg/receivepolicy/guard_test.go
+++ b/pkg/receivepolicy/guard_test.go
@@ -1,0 +1,105 @@
+package receivepolicy
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+func TestGuardSelectors(t *testing.T) {
+	cases := map[string]string{
+		"balanceOf(bytes)":          BalanceOfSelector,
+		"claim(address,bytes)":      ClaimSelector,
+		"burnBlockedReceipt(bytes)": BurnBlockedReceiptSelector,
+	}
+	for sig, want := range cases {
+		if got := selector(sig); got != want {
+			t.Errorf("%s: expected %s, got %s", sig, want, got)
+		}
+	}
+}
+
+func sampleReceipt() ClaimReceiptV1 {
+	return ClaimReceiptV1{
+		Version:           ReceiptVersion,
+		Token:             common.HexToAddress("0x20c0000000000000000000000000000000000001"),
+		RecoveryAuthority: common.HexToAddress("0x1111111111111111111111111111111111111111"),
+		Originator:        common.HexToAddress("0x2222222222222222222222222222222222222222"),
+		Recipient:         common.HexToAddress("0x3333333333333333333333333333333333333333"),
+		BlockedAt:         1717000000,
+		BlockedNonce:      42,
+		BlockedReason:     BlockedReasonReceivePolicy,
+		Kind:              InboundKindMint,
+		Memo:              common.HexToHash("0xabcd"),
+	}
+}
+
+func TestClaimReceiptRoundtrip(t *testing.T) {
+	want := sampleReceipt()
+	encoded, err := want.Encode()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	// All fields are static, so the ABI tuple encoding is 10 * 32 bytes.
+	if len(encoded) != 320 {
+		t.Errorf("expected 320 bytes, got %d", len(encoded))
+	}
+	got, err := DecodeClaimReceiptV1(encoded)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if got != want {
+		t.Errorf("roundtrip mismatch:\n want %+v\n got  %+v", want, got)
+	}
+}
+
+func TestGuardCallEncode(t *testing.T) {
+	receipt, err := sampleReceipt().Encode()
+	if err != nil {
+		t.Fatalf("encode error: %v", err)
+	}
+	to := common.HexToAddress("0x4444444444444444444444444444444444444444")
+
+	for _, tc := range []struct {
+		name string
+		call func() (Call, error)
+		sel  string
+	}{
+		{"balanceOf", func() (Call, error) { return BalanceOf(receipt) }, BalanceOfSelector},
+		{"claim", func() (Call, error) { return Claim(to, receipt) }, ClaimSelector},
+		{"burn", func() (Call, error) { return BurnBlockedReceipt(receipt) }, BurnBlockedReceiptSelector},
+	} {
+		call, err := tc.call()
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if call.To != receivePolicyGuardAddress {
+			t.Errorf("%s: unexpected target %s", tc.name, call.To.Hex())
+		}
+		if got := "0x" + hex.EncodeToString(call.Data[:4]); got != tc.sel {
+			t.Errorf("%s: expected selector %s, got %s", tc.name, tc.sel, got)
+		}
+	}
+}
+
+func TestDecodeClaimReceiptV1_Invalid(t *testing.T) {
+	// Wrong length.
+	if _, err := DecodeClaimReceiptV1(make([]byte, 64)); err == nil {
+		t.Error("expected error for short receipt")
+	}
+	// Correct length but unsupported version (version field is the first word).
+	bad := make([]byte, 320)
+	bad[31] = 2 // version = 2
+	if _, err := DecodeClaimReceiptV1(bad); err == nil {
+		t.Error("expected error for unsupported version")
+	}
+}
+
+func TestParseBalanceResult(t *testing.T) {
+	encoded := common.BigToHash(big.NewInt(123456)).Bytes()
+	if got := ParseBalanceResult(encoded); got.Cmp(big.NewInt(123456)) != 0 {
+		t.Errorf("expected 123456, got %s", got)
+	}
+}

--- a/pkg/receivepolicy/registry.go
+++ b/pkg/receivepolicy/registry.go
@@ -1,0 +1,185 @@
+package receivepolicy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+// TIP403RegistryAddress is the address of the TIP-403 registry precompile.
+const TIP403RegistryAddress = "0x403C000000000000000000000000000000000000"
+
+// Function selectors for the T6/TIP-1028 receive-policy functions.
+const (
+	// SetReceivePolicySelector is the selector for setReceivePolicy(uint64,uint64,address).
+	SetReceivePolicySelector = "0xdda03d86"
+	// ReceivePolicySelector is the selector for receivePolicy(address).
+	ReceivePolicySelector = "0xe111e611"
+	// ValidateReceivePolicySelector is the selector for validateReceivePolicy(address,address,address).
+	ValidateReceivePolicySelector = "0xb72b0c59"
+)
+
+// PolicyType matches the ITIP403Registry.PolicyType enum.
+const (
+	PolicyTypeWhitelist = 0
+	PolicyTypeBlacklist = 1
+	PolicyTypeCompound  = 2
+)
+
+// BlockedReason matches the ITIP403Registry.BlockedReason enum. It is the reason
+// an inbound transfer or mint was blocked by a receive policy.
+const (
+	BlockedReasonNone          = 0
+	BlockedReasonTokenFilter   = 1
+	BlockedReasonReceivePolicy = 2
+)
+
+// Call represents an EVM call with target address and calldata.
+type Call struct {
+	To   common.Address
+	Data []byte
+}
+
+// ReceivePolicy is an account's receive-policy configuration as returned by
+// receivePolicy(address).
+type ReceivePolicy struct {
+	HasReceivePolicy  bool
+	SenderPolicyID    uint64
+	SenderPolicyType  uint8
+	TokenFilterID     uint64
+	TokenFilterType   uint8
+	RecoveryAuthority common.Address
+}
+
+var tip403RegistryAddress = common.HexToAddress(TIP403RegistryAddress)
+
+var (
+	setReceivePolicyABI      abi.ABI
+	receivePolicyABI         abi.ABI
+	validateReceivePolicyABI abi.ABI
+)
+
+func mustParseABI(json string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse ABI: %v", err))
+	}
+	return parsed
+}
+
+func init() {
+	setReceivePolicyABI = mustParseABI(`[{
+		"name": "setReceivePolicy",
+		"type": "function",
+		"inputs": [
+			{"name": "senderPolicyId", "type": "uint64"},
+			{"name": "tokenFilterId", "type": "uint64"},
+			{"name": "recoveryAuthority", "type": "address"}
+		]
+	}]`)
+
+	receivePolicyABI = mustParseABI(`[{
+		"name": "receivePolicy",
+		"type": "function",
+		"inputs": [
+			{"name": "account", "type": "address"}
+		],
+		"outputs": [
+			{"name": "hasReceivePolicy", "type": "bool"},
+			{"name": "senderPolicyId", "type": "uint64"},
+			{"name": "senderPolicyType", "type": "uint8"},
+			{"name": "tokenFilterId", "type": "uint64"},
+			{"name": "tokenFilterType", "type": "uint8"},
+			{"name": "recoveryAuthority", "type": "address"}
+		]
+	}]`)
+
+	validateReceivePolicyABI = mustParseABI(`[{
+		"name": "validateReceivePolicy",
+		"type": "function",
+		"inputs": [
+			{"name": "token", "type": "address"},
+			{"name": "sender", "type": "address"},
+			{"name": "receiver", "type": "address"}
+		],
+		"outputs": [
+			{"name": "authorized", "type": "bool"},
+			{"name": "blockedReason", "type": "uint8"}
+		]
+	}]`)
+}
+
+// GetTIP403RegistryAddress returns the TIP-403 registry precompile address.
+func GetTIP403RegistryAddress() common.Address {
+	return tip403RegistryAddress
+}
+
+// SetReceivePolicy builds a setReceivePolicy(uint64,uint64,address) call.
+//
+// It sets the caller's receive policy. senderPolicyID and tokenFilterID are
+// TIP-403 policy IDs (0 means unset). recoveryAuthority is the address allowed
+// to claim blocked funds; the zero address means blocked funds cannot be
+// recovered.
+func SetReceivePolicy(senderPolicyID, tokenFilterID uint64, recoveryAuthority common.Address) (Call, error) {
+	data, err := setReceivePolicyABI.Pack("setReceivePolicy", senderPolicyID, tokenFilterID, recoveryAuthority)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode setReceivePolicy: %w", err)
+	}
+	return Call{To: tip403RegistryAddress, Data: data}, nil
+}
+
+// ReceivePolicyCall builds a receivePolicy(address) call. Parse the result with
+// ParseReceivePolicyResult.
+func ReceivePolicyCall(account common.Address) (Call, error) {
+	data, err := receivePolicyABI.Pack("receivePolicy", account)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode receivePolicy: %w", err)
+	}
+	return Call{To: tip403RegistryAddress, Data: data}, nil
+}
+
+// ParseReceivePolicyResult parses the result of a receivePolicy call.
+func ParseReceivePolicyResult(result []byte) (ReceivePolicy, error) {
+	values, err := receivePolicyABI.Unpack("receivePolicy", result)
+	if err != nil {
+		return ReceivePolicy{}, fmt.Errorf("failed to decode receivePolicy result: %w", err)
+	}
+	if len(values) != 6 {
+		return ReceivePolicy{}, fmt.Errorf("expected 6 return values, got %d", len(values))
+	}
+	return ReceivePolicy{
+		HasReceivePolicy:  values[0].(bool),
+		SenderPolicyID:    values[1].(uint64),
+		SenderPolicyType:  values[2].(uint8),
+		TokenFilterID:     values[3].(uint64),
+		TokenFilterType:   values[4].(uint8),
+		RecoveryAuthority: values[5].(common.Address),
+	}, nil
+}
+
+// ValidateReceivePolicy builds a validateReceivePolicy(address,address,address)
+// call. It checks whether sender may send token to receiver. Parse the result
+// with ParseValidateReceivePolicyResult.
+func ValidateReceivePolicy(token, sender, receiver common.Address) (Call, error) {
+	data, err := validateReceivePolicyABI.Pack("validateReceivePolicy", token, sender, receiver)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode validateReceivePolicy: %w", err)
+	}
+	return Call{To: tip403RegistryAddress, Data: data}, nil
+}
+
+// ParseValidateReceivePolicyResult parses the result of a validateReceivePolicy
+// call. authorized is true when the transfer is allowed; otherwise blockedReason
+// holds the reason (one of the BlockedReason constants).
+func ParseValidateReceivePolicyResult(result []byte) (authorized bool, blockedReason uint8, err error) {
+	values, err := validateReceivePolicyABI.Unpack("validateReceivePolicy", result)
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to decode validateReceivePolicy result: %w", err)
+	}
+	if len(values) != 2 {
+		return false, 0, fmt.Errorf("expected 2 return values, got %d", len(values))
+	}
+	return values[0].(bool), values[1].(uint8), nil
+}

--- a/pkg/receivepolicy/registry.go
+++ b/pkg/receivepolicy/registry.go
@@ -119,9 +119,10 @@ func GetTIP403RegistryAddress() common.Address {
 // SetReceivePolicy builds a setReceivePolicy(uint64,uint64,address) call.
 //
 // It sets the caller's receive policy. senderPolicyID and tokenFilterID are
-// TIP-403 policy IDs (0 means unset). recoveryAuthority is the address allowed
-// to claim blocked funds; the zero address means blocked funds cannot be
-// recovered.
+// TIP-403 policy IDs; the built-in policies 0 (reject all) and 1 (allow all)
+// are also valid, so use 1 and 1 to effectively disable filtering.
+// recoveryAuthority is who may claim blocked funds: the zero address means the
+// transfer originator, and any nonzero address names that claimer.
 func SetReceivePolicy(senderPolicyID, tokenFilterID uint64, recoveryAuthority common.Address) (Call, error) {
 	data, err := setReceivePolicyABI.Pack("setReceivePolicy", senderPolicyID, tokenFilterID, recoveryAuthority)
 	if err != nil {

--- a/pkg/receivepolicy/registry_test.go
+++ b/pkg/receivepolicy/registry_test.go
@@ -1,0 +1,99 @@
+package receivepolicy
+
+import (
+	"bytes"
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func selector(sig string) string {
+	return "0x" + hex.EncodeToString(crypto.Keccak256([]byte(sig))[:4])
+}
+
+func TestReceivePolicySelectors(t *testing.T) {
+	cases := map[string]string{
+		"setReceivePolicy(uint64,uint64,address)":        SetReceivePolicySelector,
+		"receivePolicy(address)":                         ReceivePolicySelector,
+		"validateReceivePolicy(address,address,address)": ValidateReceivePolicySelector,
+	}
+	for sig, want := range cases {
+		if got := selector(sig); got != want {
+			t.Errorf("%s: expected %s, got %s", sig, want, got)
+		}
+	}
+}
+
+func TestSetReceivePolicyEncode(t *testing.T) {
+	recovery := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	call, err := SetReceivePolicy(7, 9, recovery)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if call.To != tip403RegistryAddress {
+		t.Errorf("unexpected target: %s", call.To.Hex())
+	}
+	if got := "0x" + hex.EncodeToString(call.Data[:4]); got != SetReceivePolicySelector {
+		t.Errorf("expected selector %s, got %s", SetReceivePolicySelector, got)
+	}
+}
+
+func TestParseReceivePolicyResult(t *testing.T) {
+	recovery := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	want := ReceivePolicy{
+		HasReceivePolicy:  true,
+		SenderPolicyID:    11,
+		SenderPolicyType:  PolicyTypeWhitelist,
+		TokenFilterID:     22,
+		TokenFilterType:   PolicyTypeBlacklist,
+		RecoveryAuthority: recovery,
+	}
+	encoded, err := receivePolicyABI.Methods["receivePolicy"].Outputs.Pack(
+		want.HasReceivePolicy, want.SenderPolicyID, want.SenderPolicyType,
+		want.TokenFilterID, want.TokenFilterType, want.RecoveryAuthority,
+	)
+	if err != nil {
+		t.Fatalf("failed to pack outputs: %v", err)
+	}
+	got, err := ParseReceivePolicyResult(encoded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected %+v, got %+v", want, got)
+	}
+}
+
+func TestParseValidateReceivePolicyResult(t *testing.T) {
+	encoded, err := validateReceivePolicyABI.Methods["validateReceivePolicy"].Outputs.Pack(
+		false, uint8(BlockedReasonTokenFilter),
+	)
+	if err != nil {
+		t.Fatalf("failed to pack outputs: %v", err)
+	}
+	authorized, reason, err := ParseValidateReceivePolicyResult(encoded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if authorized {
+		t.Error("expected authorized=false")
+	}
+	if reason != BlockedReasonTokenFilter {
+		t.Errorf("expected reason %d, got %d", BlockedReasonTokenFilter, reason)
+	}
+}
+
+func TestValidateReceivePolicyEncode(t *testing.T) {
+	token := common.HexToAddress("0x20c0000000000000000000000000000000000001")
+	sender := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	receiver := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	call, err := ValidateReceivePolicy(token, sender, receiver)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.HasPrefix(call.Data, common.FromHex(ValidateReceivePolicySelector)) {
+		t.Error("missing validateReceivePolicy selector")
+	}
+}


### PR DESCRIPTION
Adds a `receivepolicy` package for TIP-1028: set/read/validate receive policies on the TIP-403 registry, and balanceOf/claim/burn plus event decoding for the ReceivePolicyGuard.

Part of OSS-397