### PR TITLE
fix(transaction): copy AwaitingFeePayer in Tx.Clone()

### DIFF
--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -231,6 +231,7 @@ func (tx *Tx) Clone() *Tx {
 		ValidBefore:          tx.ValidBefore,
 		ValidAfter:           tx.ValidAfter,
 		FeeToken:             tx.FeeToken,
+		AwaitingFeePayer:     tx.AwaitingFeePayer,
 		From:                 tx.From,
 	}
 

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -453,3 +453,24 @@ func TestTransaction_Clone(t *testing.T) {
 		assert.Empty(t, cloned.AccessList)
 	})
 }
+
+func TestClonePreservesAwaitingFeePayer(t *testing.T) {
+	recipient := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	tx := New()
+	tx.Gas = 21000
+	tx.MaxFeePerGas = big.NewInt(1_000_000_000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1_000_000_000)
+	tx.FeeToken = AlphaUSDAddress
+	tx.AwaitingFeePayer = true
+	tx.Calls = []Call{{To: &recipient, Value: big.NewInt(0), Data: []byte{}}}
+
+	clone := tx.Clone()
+	assert.True(t, clone.AwaitingFeePayer, "clone must preserve AwaitingFeePayer")
+
+	origHash, err := GetSignPayload(tx)
+	assert.NoError(t, err)
+	cloneHash, err := GetSignPayload(clone)
+	assert.NoError(t, err)
+	assert.Equal(t, origHash, cloneHash, "clone must produce the same signing payload as the original")
+}


### PR DESCRIPTION
# fix(transaction): copy AwaitingFeePayer in Tx.Clone()

## Summary

`Tx.Clone()` copied every field of the transaction except `AwaitingFeePayer`. For
sponsored (fee-payer) transactions this silently changes the bytes the sender signs,
so a signature produced over a clone never verifies on chain.

## Root cause

`SerializeForSigning` branches on `AwaitingFeePayer`:

```go
skipFeeToken := opts.ForSigning && opts.Format == FormatNormal &&
    (tx.AwaitingFeePayer || tx.FeePayerSignature != nil)
```

When the flag is true the signing payload (a) skips `fee_token` and (b) writes the
`0x00` fee-payer marker in field 11. `Clone()` left the flag at its zero value
(`false`), so the clone serialized to the non-sponsored form instead.

## Impact

- Severity: **high**
- A clone of a sponsored tx is signed over a different payload than the original.
- The sender signature fails verification once a fee payer sponsors it — funds path
  for sponsored transactions is broken, and the failure is silent until broadcast.
- `Clone()` is explicitly documented for producing transaction variations, so this is
  on the happy path.

## Fix

Add the missing field to the struct literal in `Clone()`:

```go
AwaitingFeePayer: tx.AwaitingFeePayer,
```

## Verification

`TestClonePreservesAwaitingFeePayer` asserts the original and the clone produce an
identical signing hash. Fails before the change, passes after. `go test ./pkg/transaction/`
is green.