### PR TITLE
fix(transaction): reject malformed field 11 instead of dropping it

### DIFF
--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -175,7 +175,12 @@ func Deserialize(serialized string) (*Tx, error) {
 			tx.FeePayerSignature = nil
 			tx.AwaitingFeePayer = true
 		} else if len(feePayerSigRaw) > 0 {
-			// Non-empty bytes that aren't 0x00 - unusual case
+			// A 0x76 transaction's field 11 may only be empty, the single 0x00 marker, or
+			// a [yParity, r, s] signature tuple. Any other non-empty byte string (e.g. a
+			// bare sender address, which belongs to the 0x78 signing form) is malformed.
+			// Reject it instead of silently discarding it.
+			return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): unexpected %d-byte value",
+				ErrInvalidTransaction, len(feePayerSigRaw))
 		}
 	} else if feePayerSigTuple, ok := raw[11].([]interface{}); ok && len(feePayerSigTuple) == 3 {
 		// Signature tuple: [yParity, r, s]

--- a/pkg/transaction/eserialize_field11_test.go
+++ b/pkg/transaction/eserialize_field11_test.go
@@ -1,0 +1,41 @@
+package transaction
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A 0x76 transaction whose field 11 carries a bare (non-tuple, non-0x00) byte string
+// is malformed and must be rejected rather than silently ignored.
+func TestDeserializeRejectsMalformedField11(t *testing.T) {
+	addr := make([]byte, 20)
+	addr[0] = 0xab // a 20-byte sender address — only valid in the 0x78 signing form
+
+	fields := []interface{}{
+		[]byte{0x10},       // 0  chainId
+		[]byte{},           // 1  maxPriorityFeePerGas
+		[]byte{},           // 2  maxFeePerGas
+		[]byte{0x52, 0x08}, // 3  gas
+		[]interface{}{},    // 4  calls
+		[]interface{}{},    // 5  accessList
+		[]byte{},           // 6  nonceKey
+		[]byte{},           // 7  nonce
+		[]byte{},           // 8  validBefore
+		[]byte{},           // 9  validAfter
+		[]byte{},           // 10 feeToken
+		addr,               // 11 feePayerSignatureOrSender (malformed)
+		[]interface{}{},    // 12 authorizationList
+	}
+
+	rlpBytes, err := rlp.EncodeToBytes(fields)
+	require.NoError(t, err)
+	serialized := "0x76" + hex.EncodeToString(rlpBytes)
+
+	_, err = Deserialize(serialized)
+	require.Error(t, err, "malformed field 11 must be rejected")
+	assert.Contains(t, err.Error(), "field 11")
+}


### PR DESCRIPTION
### Don't silently swallow a malformed field 11

So there's this branch in `Deserialize` that always bugged me:

```go
} else if len(feePayerSigRaw) > 0 {
    // Non-empty bytes that aren't 0x00 - unusual case
}
```

That's it. The "unusual case" is just... an empty block. If field 11
(`feePayerSignatureOrSender`) decodes to a non-empty byte string that isn't the
single `0x00` marker, we shrug and move on. The data is gone, no error, nothing.

Why does that matter? Field 11 is security-relevant — it's where the fee-payer
signature or the await-fee-payer marker lives. For a `0x76` transaction the only
legal shapes are:

- empty (`0x80`) — no fee payer,
- a single `0x00` byte — awaiting fee payer,
- a `[yParity, r, s]` tuple — actual fee-payer signature.

A bare byte string (say, a 20-byte address — which only belongs in the `0x78`
*signing* form, not on the wire) is malformed. Accepting it means we happily parse
a transaction that nobody should consider valid, and we throw away whatever was
there without telling the caller. A parser for a security-critical format should
reject what it doesn't understand, not guess.

So now we return an error:

```go
return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): unexpected %d-byte value",
    ErrInvalidTransaction, len(feePayerSigRaw))
```

Added `TestDeserializeRejectsMalformedField11`, which hand-builds a 13-field tx with
a 20-byte value in slot 11 and checks we now error out. Rest of the suite is still
green.