### PR TITLE
feat: add storage credits

### DIFF
--- a/.changelog/t7-storage-credits.md
+++ b/.changelog/t7-storage-credits.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: minor
+---
+
+Add the `storagecredits` package with T7 bindings for the TIP-1060 storage credits precompile (`setMode`, `setBudget`, `balanceOf`, `modeOf`, `budgetOf`) and the StablecoinDEX `storageCredits(address)` view (TIP-1064). Update example fees to sit above the T7 dynamic base-fee cap (TIP-1067) and clarify that fees are denominated in attodollars per gas.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ func main() {
     transferData := buildERC20TransferData(recipient, amount)
 
     tx := transaction.NewDefault(transaction.ChainIdModerato)
-    tx.MaxFeePerGas = big.NewInt(2000000000)
+    // Fees are in attodollars (1e-18 USD) per gas. Since T7 the base fee is
+    // dynamic, capped at 1.2e10; set max fee at or above the cap to stay includable.
+    tx.MaxFeePerGas = big.NewInt(20000000000)
     tx.MaxPriorityFeePerGas = big.NewInt(1000000000)
     tx.Gas = 100000
     tx.Calls = []transaction.Call{{
@@ -110,7 +112,8 @@ func buildERC20TransferData(to common.Address, amount *big.Int) []byte {
 
 ```go
 tx := transaction.NewDefault(transaction.ChainIdMainnet)
-tx.MaxFeePerGas = big.NewInt(2000000000)
+// Fees are in attodollars (1e-18 USD) per gas; T7 caps the base fee at 1.2e10.
+tx.MaxFeePerGas = big.NewInt(20000000000)
 tx.MaxPriorityFeePerGas = big.NewInt(1000000000)
 tx.Gas = 100000
 tx.Calls = []transaction.Call{{

--- a/examples/parallel-nonces/main.go
+++ b/examples/parallel-nonces/main.go
@@ -128,8 +128,8 @@ func main() {
 				SetNonceKey(key).
 				SetNonce(nonce).
 				SetGas(100000).
-				SetMaxFeePerGas(big.NewInt(10000000000)).
-				SetMaxPriorityFeePerGas(big.NewInt(1000000000)).
+				SetMaxFeePerGas(big.NewInt(20000000000)).        // attodollars/gas; above the T7 base-fee cap (1.2e10)
+				SetMaxPriorityFeePerGas(big.NewInt(1000000000)). // attodollars/gas
 				AddCall(recipient, big.NewInt(0), []byte{}).
 				Build()
 

--- a/examples/simple-send/main.go
+++ b/examples/simple-send/main.go
@@ -79,8 +79,8 @@ func main() {
 	tx := transaction.NewBuilder(big.NewInt(chainID)).
 		SetNonce(nonce).
 		SetGas(100000).
-		SetMaxFeePerGas(big.NewInt(10000000000)).        // 10 gwei
-		SetMaxPriorityFeePerGas(big.NewInt(1000000000)). // 1 gwei
+		SetMaxFeePerGas(big.NewInt(20000000000)).        // attodollars/gas; above the T7 base-fee cap (1.2e10)
+		SetMaxPriorityFeePerGas(big.NewInt(1000000000)). // attodollars/gas
 		AddCall(
 			common.HexToAddress(recipientAddress),
 			big.NewInt(0),

--- a/pkg/storagecredits/doc.go
+++ b/pkg/storagecredits/doc.go
@@ -1,0 +1,28 @@
+// Package storagecredits provides helpers for the T7 storage credits feature.
+//
+// Storage credits (TIP-1060) lower storage gas costs when an account reuses
+// storage it previously freed. Deleting a storage slot mints one credit for the
+// owning account; creating a slot later can consume a credit to offset the
+// storage creation cost. Credits are per-account, non-transferable, and
+// non-expiring.
+//
+// # Storage Credits precompile (TIP-1060)
+//
+// The precompile lives at 0x1060000000000000000000000000000000000000 and lets
+// each account read its credit state and choose how credits apply to its own
+// storage creations:
+//   - balanceOf: read an account's credit balance
+//   - modeOf: read an account's current storage creation mode
+//   - budgetOf: read an account's remaining Direct-spend budget
+//   - setMode: choose Refund (default), Preserve, or Direct mode
+//   - setBudget: switch to Direct mode with a bounded credit budget
+//
+// Mode and budget are transaction-local: they reset every transaction, so a
+// contract wanting non-default behavior must call setMode or setBudget in each
+// transaction.
+//
+// # StablecoinDEX order storage credits (TIP-1064)
+//
+// The StablecoinDEX tracks per-user order storage credits and exposes them via
+// the storageCredits(address) view. See DEXStorageCredits.
+package storagecredits

--- a/pkg/storagecredits/storagecredits.go
+++ b/pkg/storagecredits/storagecredits.go
@@ -1,0 +1,204 @@
+package storagecredits
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+// StorageCreditsAddress is the address of the TIP-1060 storage credits precompile.
+const StorageCreditsAddress = "0x1060000000000000000000000000000000000000"
+
+// Function selectors for the TIP-1060 storage credits precompile.
+const (
+	// SetModeSelector is the selector for setMode(uint8).
+	SetModeSelector = "0x21175b4a"
+	// SetBudgetSelector is the selector for setBudget(uint64).
+	SetBudgetSelector = "0xffe295c3"
+	// BalanceOfSelector is the selector for balanceOf(address).
+	BalanceOfSelector = "0x70a08231"
+	// ModeOfSelector is the selector for modeOf(address).
+	ModeOfSelector = "0x13668995"
+	// BudgetOfSelector is the selector for budgetOf(address).
+	BudgetOfSelector = "0x7865e71f"
+	// DEXStorageCreditsSelector is the selector for the StablecoinDEX
+	// storageCredits(address) view (TIP-1064).
+	DEXStorageCreditsSelector = "0x4d65338b"
+)
+
+// Mode is an account's storage creation mode as defined by TIP-1060.
+type Mode uint8
+
+const (
+	// ModeRefund charges the credit value upfront and refunds it at
+	// end-of-transaction if a credit is available. It is the default.
+	ModeRefund Mode = 0
+	// ModePreserve always charges the credit value and never consumes credits.
+	ModePreserve Mode = 1
+	// ModeDirect consumes an available credit synchronously, bounded by the
+	// account's Direct budget.
+	ModeDirect Mode = 2
+)
+
+// Call represents an EVM call with target address and calldata.
+type Call struct {
+	To   common.Address
+	Data []byte
+}
+
+var storageCreditsAddress = common.HexToAddress(StorageCreditsAddress)
+
+var (
+	setModeABI           abi.ABI
+	setBudgetABI         abi.ABI
+	balanceOfABI         abi.ABI
+	modeOfABI            abi.ABI
+	budgetOfABI          abi.ABI
+	dexStorageCreditsABI abi.ABI
+)
+
+func mustParseABI(json string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse ABI: %v", err))
+	}
+	return parsed
+}
+
+func init() {
+	setModeABI = mustParseABI(`[{
+		"name": "setMode",
+		"type": "function",
+		"inputs": [{"name": "newMode", "type": "uint8"}]
+	}]`)
+
+	setBudgetABI = mustParseABI(`[{
+		"name": "setBudget",
+		"type": "function",
+		"inputs": [{"name": "creditBudget", "type": "uint64"}]
+	}]`)
+
+	balanceOfABI = mustParseABI(`[{
+		"name": "balanceOf",
+		"type": "function",
+		"inputs": [{"name": "account", "type": "address"}],
+		"outputs": [{"name": "", "type": "uint64"}]
+	}]`)
+
+	modeOfABI = mustParseABI(`[{
+		"name": "modeOf",
+		"type": "function",
+		"inputs": [{"name": "account", "type": "address"}],
+		"outputs": [{"name": "", "type": "uint8"}]
+	}]`)
+
+	budgetOfABI = mustParseABI(`[{
+		"name": "budgetOf",
+		"type": "function",
+		"inputs": [{"name": "account", "type": "address"}],
+		"outputs": [{"name": "", "type": "uint64"}]
+	}]`)
+
+	dexStorageCreditsABI = mustParseABI(`[{
+		"name": "storageCredits",
+		"type": "function",
+		"inputs": [{"name": "user", "type": "address"}],
+		"outputs": [{"name": "credits", "type": "uint64"}]
+	}]`)
+}
+
+// GetStorageCreditsAddress returns the TIP-1060 precompile address.
+func GetStorageCreditsAddress() common.Address {
+	return storageCreditsAddress
+}
+
+// SetMode builds a setMode(uint8) call that sets the caller's storage creation
+// mode for the current transaction. The precompile rejects modes outside
+// {Refund, Preserve, Direct}, so those are rejected here too.
+func SetMode(mode Mode) (Call, error) {
+	if mode != ModeRefund && mode != ModePreserve && mode != ModeDirect {
+		return Call{}, fmt.Errorf("invalid storage creation mode: %d", mode)
+	}
+	data, err := setModeABI.Pack("setMode", uint8(mode))
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode setMode: %w", err)
+	}
+	return Call{To: storageCreditsAddress, Data: data}, nil
+}
+
+// SetBudget builds a setBudget(uint64) call that switches the caller to Direct
+// mode with the given credit budget for the current transaction.
+func SetBudget(creditBudget uint64) (Call, error) {
+	data, err := setBudgetABI.Pack("setBudget", creditBudget)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode setBudget: %w", err)
+	}
+	return Call{To: storageCreditsAddress, Data: data}, nil
+}
+
+// BalanceOf builds a balanceOf(address) call. Parse the result with
+// ParseUint64Result.
+func BalanceOf(account common.Address) (Call, error) {
+	data, err := balanceOfABI.Pack("balanceOf", account)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode balanceOf: %w", err)
+	}
+	return Call{To: storageCreditsAddress, Data: data}, nil
+}
+
+// ModeOf builds a modeOf(address) call. Parse the result with ParseModeResult.
+func ModeOf(account common.Address) (Call, error) {
+	data, err := modeOfABI.Pack("modeOf", account)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode modeOf: %w", err)
+	}
+	return Call{To: storageCreditsAddress, Data: data}, nil
+}
+
+// BudgetOf builds a budgetOf(address) call. Parse the result with
+// ParseUint64Result.
+func BudgetOf(account common.Address) (Call, error) {
+	data, err := budgetOfABI.Pack("budgetOf", account)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode budgetOf: %w", err)
+	}
+	return Call{To: storageCreditsAddress, Data: data}, nil
+}
+
+// DEXStorageCredits builds a storageCredits(address) call against the
+// StablecoinDEX precompile (TIP-1064). Parse the result with ParseUint64Result.
+func DEXStorageCredits(user common.Address) (Call, error) {
+	data, err := dexStorageCreditsABI.Pack("storageCredits", user)
+	if err != nil {
+		return Call{}, fmt.Errorf("failed to encode storageCredits: %w", err)
+	}
+	return Call{To: transaction.StablecoinDEXAddress, Data: data}, nil
+}
+
+// ParseUint64Result decodes a single uint64 returned by balanceOf, budgetOf, or
+// storageCredits.
+func ParseUint64Result(result []byte) (uint64, error) {
+	values, err := balanceOfABI.Unpack("balanceOf", result)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode uint64 result: %w", err)
+	}
+	if len(values) != 1 {
+		return 0, fmt.Errorf("expected 1 return value, got %d", len(values))
+	}
+	return values[0].(uint64), nil
+}
+
+// ParseModeResult decodes the Mode returned by modeOf.
+func ParseModeResult(result []byte) (Mode, error) {
+	values, err := modeOfABI.Unpack("modeOf", result)
+	if err != nil {
+		return 0, fmt.Errorf("failed to decode modeOf result: %w", err)
+	}
+	if len(values) != 1 {
+		return 0, fmt.Errorf("expected 1 return value, got %d", len(values))
+	}
+	return Mode(values[0].(uint8)), nil
+}

--- a/pkg/storagecredits/storagecredits.go
+++ b/pkg/storagecredits/storagecredits.go
@@ -181,6 +181,9 @@ func DEXStorageCredits(user common.Address) (Call, error) {
 // ParseUint64Result decodes a single uint64 returned by balanceOf, budgetOf, or
 // storageCredits.
 func ParseUint64Result(result []byte) (uint64, error) {
+	if len(result) != 32 {
+		return 0, fmt.Errorf("invalid uint64 result length: expected 32, got %d", len(result))
+	}
 	values, err := balanceOfABI.Unpack("balanceOf", result)
 	if err != nil {
 		return 0, fmt.Errorf("failed to decode uint64 result: %w", err)
@@ -193,6 +196,9 @@ func ParseUint64Result(result []byte) (uint64, error) {
 
 // ParseModeResult decodes the Mode returned by modeOf.
 func ParseModeResult(result []byte) (Mode, error) {
+	if len(result) != 32 {
+		return 0, fmt.Errorf("invalid modeOf result length: expected 32, got %d", len(result))
+	}
 	values, err := modeOfABI.Unpack("modeOf", result)
 	if err != nil {
 		return 0, fmt.Errorf("failed to decode modeOf result: %w", err)
@@ -200,5 +206,9 @@ func ParseModeResult(result []byte) (Mode, error) {
 	if len(values) != 1 {
 		return 0, fmt.Errorf("expected 1 return value, got %d", len(values))
 	}
-	return Mode(values[0].(uint8)), nil
+	mode := Mode(values[0].(uint8))
+	if mode != ModeRefund && mode != ModePreserve && mode != ModeDirect {
+		return 0, fmt.Errorf("invalid storage creation mode: %d", mode)
+	}
+	return mode, nil
 }

--- a/pkg/storagecredits/storagecredits_test.go
+++ b/pkg/storagecredits/storagecredits_test.go
@@ -1,0 +1,129 @@
+package storagecredits
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/tempoxyz/tempo-go/pkg/transaction"
+)
+
+func selector(sig string) string {
+	return "0x" + hex.EncodeToString(crypto.Keccak256([]byte(sig))[:4])
+}
+
+func TestSelectors(t *testing.T) {
+	cases := map[string]string{
+		"setMode(uint8)":          SetModeSelector,
+		"setBudget(uint64)":       SetBudgetSelector,
+		"balanceOf(address)":      BalanceOfSelector,
+		"modeOf(address)":         ModeOfSelector,
+		"budgetOf(address)":       BudgetOfSelector,
+		"storageCredits(address)": DEXStorageCreditsSelector,
+	}
+	for sig, want := range cases {
+		if got := selector(sig); got != want {
+			t.Errorf("%s: expected %s, got %s", sig, want, got)
+		}
+	}
+}
+
+func TestEncodeSelectors(t *testing.T) {
+	account := common.HexToAddress("0x1111111111111111111111111111111111111111")
+	cases := []struct {
+		name     string
+		call     func() (Call, error)
+		to       common.Address
+		selector string
+	}{
+		{"SetMode", func() (Call, error) { return SetMode(ModeDirect) }, storageCreditsAddress, SetModeSelector},
+		{"SetBudget", func() (Call, error) { return SetBudget(5) }, storageCreditsAddress, SetBudgetSelector},
+		{"BalanceOf", func() (Call, error) { return BalanceOf(account) }, storageCreditsAddress, BalanceOfSelector},
+		{"ModeOf", func() (Call, error) { return ModeOf(account) }, storageCreditsAddress, ModeOfSelector},
+		{"BudgetOf", func() (Call, error) { return BudgetOf(account) }, storageCreditsAddress, BudgetOfSelector},
+		{"DEXStorageCredits", func() (Call, error) { return DEXStorageCredits(account) }, transaction.StablecoinDEXAddress, DEXStorageCreditsSelector},
+	}
+	for _, tc := range cases {
+		call, err := tc.call()
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if call.To != tc.to {
+			t.Errorf("%s: unexpected target %s", tc.name, call.To.Hex())
+		}
+		if got := "0x" + hex.EncodeToString(call.Data[:4]); got != tc.selector {
+			t.Errorf("%s: expected selector %s, got %s", tc.name, tc.selector, got)
+		}
+	}
+}
+
+func TestEncodeArgsRoundTrip(t *testing.T) {
+	account := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	modeCall, _ := SetMode(ModeDirect)
+	args, err := setModeABI.Methods["setMode"].Inputs.Unpack(modeCall.Data[4:])
+	if err != nil {
+		t.Fatalf("setMode unpack: %v", err)
+	}
+	if args[0].(uint8) != uint8(ModeDirect) {
+		t.Errorf("setMode arg: got %d", args[0])
+	}
+
+	budgetCall, _ := SetBudget(7)
+	args, err = setBudgetABI.Methods["setBudget"].Inputs.Unpack(budgetCall.Data[4:])
+	if err != nil {
+		t.Fatalf("setBudget unpack: %v", err)
+	}
+	if args[0].(uint64) != 7 {
+		t.Errorf("setBudget arg: got %d", args[0])
+	}
+
+	balCall, _ := BalanceOf(account)
+	args, err = balanceOfABI.Methods["balanceOf"].Inputs.Unpack(balCall.Data[4:])
+	if err != nil {
+		t.Fatalf("balanceOf unpack: %v", err)
+	}
+	if args[0].(common.Address) != account {
+		t.Errorf("balanceOf arg: got %s", args[0])
+	}
+}
+
+func TestSetModeRejectsInvalid(t *testing.T) {
+	if _, err := SetMode(Mode(3)); err == nil {
+		t.Error("expected error for invalid mode, got nil")
+	}
+	for _, m := range []Mode{ModeRefund, ModePreserve, ModeDirect} {
+		if _, err := SetMode(m); err != nil {
+			t.Errorf("mode %d: unexpected error: %v", m, err)
+		}
+	}
+}
+
+func TestParseUint64Result(t *testing.T) {
+	encoded, err := balanceOfABI.Methods["balanceOf"].Outputs.Pack(uint64(42))
+	if err != nil {
+		t.Fatalf("failed to pack: %v", err)
+	}
+	got, err := ParseUint64Result(encoded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("expected 42, got %d", got)
+	}
+}
+
+func TestParseModeResult(t *testing.T) {
+	encoded, err := modeOfABI.Methods["modeOf"].Outputs.Pack(uint8(ModePreserve))
+	if err != nil {
+		t.Fatalf("failed to pack: %v", err)
+	}
+	got, err := ParseModeResult(encoded)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != ModePreserve {
+		t.Errorf("expected %d, got %d", ModePreserve, got)
+	}
+}

--- a/pkg/storagecredits/storagecredits_test.go
+++ b/pkg/storagecredits/storagecredits_test.go
@@ -112,6 +112,20 @@ func TestParseUint64Result(t *testing.T) {
 	if got != 42 {
 		t.Errorf("expected 42, got %d", got)
 	}
+
+	for _, tc := range []struct {
+		name   string
+		result []byte
+	}{
+		{"short", encoded[:len(encoded)-1]},
+		{"trailing data", append(append([]byte{}, encoded...), make([]byte, 32)...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseUint64Result(tc.result); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
 }
 
 func TestParseModeResult(t *testing.T) {
@@ -125,5 +139,27 @@ func TestParseModeResult(t *testing.T) {
 	}
 	if got != ModePreserve {
 		t.Errorf("expected %d, got %d", ModePreserve, got)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		result []byte
+	}{
+		{"short", encoded[:len(encoded)-1]},
+		{"trailing data", append(append([]byte{}, encoded...), make([]byte, 32)...)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := ParseModeResult(tc.result); err == nil {
+				t.Fatal("expected error, got nil")
+			}
+		})
+	}
+
+	invalid, err := modeOfABI.Methods["modeOf"].Outputs.Pack(uint8(ModeDirect + 1))
+	if err != nil {
+		t.Fatalf("failed to pack invalid mode: %v", err)
+	}
+	if _, err := ParseModeResult(invalid); err == nil {
+		t.Fatal("expected error for invalid mode, got nil")
 	}
 }


### PR DESCRIPTION
Adds `pkg/storagecredits` with T7 bindings for the TIP-1060 storage credits precompile and the TIP-1064 DEX `storageCredits` view. Also fixes example fees to sit above the T7 base-fee cap (TIP-1067) and clarifies fees are in attodollars per gas.