### PR TITLE
test(transaction): cover malformed fee payer field lists

### DIFF
--- a/.changelog/reject-malformed-feepayer-field-lists.md
+++ b/.changelog/reject-malformed-feepayer-field-lists.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Reject malformed fee-payer signature lists in transaction field 11 instead of accepting unsupported tuple shapes.

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -182,13 +182,21 @@ func Deserialize(serialized string) (*Tx, error) {
 			return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): unexpected %d-byte value",
 				ErrInvalidTransaction, len(feePayerSigRaw))
 		}
-	} else if feePayerSigTuple, ok := raw[11].([]interface{}); ok && len(feePayerSigTuple) == 3 {
+	} else if feePayerSigTuple, ok := raw[11].([]interface{}); ok {
+		if len(feePayerSigTuple) != 3 {
+			return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): expected 3-item signature tuple, got %d items",
+				ErrInvalidTransaction, len(feePayerSigTuple))
+		}
+
 		// Signature tuple: [yParity, r, s]
 		sig, err := decodeSignature(feePayerSigTuple)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decode fee payer signature: %w", err)
 		}
 		tx.FeePayerSignature = sig
+	} else {
+		return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): unexpected type %T",
+			ErrInvalidTransaction, raw[11])
 	}
 
 	// Field 12: authorizationList (reserved for EIP-7702)

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -175,7 +175,12 @@ func Deserialize(serialized string) (*Tx, error) {
 			tx.FeePayerSignature = nil
 			tx.AwaitingFeePayer = true
 		} else if len(feePayerSigRaw) > 0 {
-			// Non-empty bytes that aren't 0x00 - unusual case
+			// A 0x76 transaction's field 11 may only be empty, the single 0x00 marker, or
+			// a [yParity, r, s] signature tuple. Any other non-empty byte string (e.g. a
+			// bare sender address, which belongs to the 0x78 signing form) is malformed.
+			// Reject it instead of silently discarding it.
+			return nil, fmt.Errorf("%w: invalid feePayerSignatureOrSender (field 11): unexpected %d-byte value",
+				ErrInvalidTransaction, len(feePayerSigRaw))
 		}
 	} else if feePayerSigTuple, ok := raw[11].([]interface{}); ok && len(feePayerSigTuple) == 3 {
 		// Signature tuple: [yParity, r, s]

--- a/pkg/transaction/eserialize_field11_test.go
+++ b/pkg/transaction/eserialize_field11_test.go
@@ -1,0 +1,41 @@
+package transaction
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A 0x76 transaction whose field 11 carries a bare (non-tuple, non-0x00) byte string
+// is malformed and must be rejected rather than silently ignored.
+func TestDeserializeRejectsMalformedField11(t *testing.T) {
+	addr := make([]byte, 20)
+	addr[0] = 0xab // a 20-byte sender address — only valid in the 0x78 signing form
+
+	fields := []interface{}{
+		[]byte{0x10},       // 0  chainId
+		[]byte{},           // 1  maxPriorityFeePerGas
+		[]byte{},           // 2  maxFeePerGas
+		[]byte{0x52, 0x08}, // 3  gas
+		[]interface{}{},    // 4  calls
+		[]interface{}{},    // 5  accessList
+		[]byte{},           // 6  nonceKey
+		[]byte{},           // 7  nonce
+		[]byte{},           // 8  validBefore
+		[]byte{},           // 9  validAfter
+		[]byte{},           // 10 feeToken
+		addr,               // 11 feePayerSignatureOrSender (malformed)
+		[]interface{}{},    // 12 authorizationList
+	}
+
+	rlpBytes, err := rlp.EncodeToBytes(fields)
+	require.NoError(t, err)
+	serialized := "0x76" + hex.EncodeToString(rlpBytes)
+
+	_, err = Deserialize(serialized)
+	require.Error(t, err, "malformed field 11 must be rejected")
+	assert.Contains(t, err.Error(), "field 11")
+}

--- a/pkg/transaction/field11_coverage_test.go
+++ b/pkg/transaction/field11_coverage_test.go
@@ -1,0 +1,39 @@
+package transaction
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeserializeRejectsMalformedField11Lists(t *testing.T) {
+	invalidLists := []struct {
+		name  string
+		value []interface{}
+	}{
+		{name: "empty", value: []interface{}{}},
+		{name: "one item", value: []interface{}{[]byte{0x00}}},
+		{name: "two items", value: []interface{}{[]byte{0x00}, []byte{0x01}}},
+		{name: "four items", value: []interface{}{[]byte{0x00}, []byte{0x01}, []byte{0x02}, []byte{0x03}}},
+	}
+
+	for _, tc := range invalidLists {
+		t.Run(tc.name, func(t *testing.T) {
+			fields := []interface{}{
+				[]byte{0x10}, []byte{}, []byte{}, []byte{0x52, 0x08},
+				[]interface{}{}, []interface{}{}, []byte{}, []byte{}, []byte{}, []byte{}, []byte{},
+				tc.value,
+				[]interface{}{},
+			}
+			raw, err := rlp.EncodeToBytes(fields)
+			require.NoError(t, err)
+
+			_, err = Deserialize("0x76" + hex.EncodeToString(raw))
+			require.Error(t, err, "field 11 %s list must be rejected", tc.name)
+			assert.Contains(t, err.Error(), "field 11")
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Self-contained companion coverage for https://github.com/tempoxyz/tempo-go/pull/68.

## Summary

- Carry malformed field 11 byte-string rejection.
- Reject malformed field 11 lists that are not three-item signature tuples.
- Add coverage and the required patch changelog.

## Key design considerations

- Includes the implementation so CI validates the coverage from main.
- Extends #68 to cover unsupported list-shaped field 11 values.