### PR TITLE
test(client): cover reordered batch error responses

### DIFF
--- a/.changelog/cover-batch-response-reordering.md
+++ b/.changelog/cover-batch-response-reordering.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Correlate JSON-RPC batch responses by request ID so reordered success and error responses remain associated with their requests.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -387,5 +387,48 @@ func (c *Client) SendBatch(ctx context.Context, batch *BatchRequest) ([]*JSONRPC
 		return nil, fmt.Errorf("failed to unmarshal batch response: %w", err)
 	}
 
-	return responses, nil
+	// JSON-RPC 2.0 permits a server to return batch responses in ANY order; the only
+	// reliable way to associate a response with its request is the `id` field. Callers
+	// index the returned slice positionally, so realign it to the request order here.
+	return reorderBatchResponses(batch.Requests(), responses), nil
+}
+
+// reorderBatchResponses realigns batch responses to the request order using the
+// JSON-RPC `id`. A request with no matching response gets a nil slot; responses whose
+// id matches no request are dropped. This makes positional indexing by the caller safe
+// even when the server reorders (or omits) replies.
+func reorderBatchResponses(requests []*JSONRPCRequest, responses []*JSONRPCResponse) []*JSONRPCResponse {
+	byID := make(map[string]*JSONRPCResponse, len(responses))
+	for _, resp := range responses {
+		if resp != nil {
+			byID[normalizeRPCID(resp.ID)] = resp
+		}
+	}
+
+	ordered := make([]*JSONRPCResponse, len(requests))
+	for i, req := range requests {
+		ordered[i] = byID[normalizeRPCID(req.ID)]
+	}
+	return ordered
+}
+
+// normalizeRPCID renders a JSON-RPC id as a stable comparison key. Request ids are
+// assigned as int, but after a round trip through JSON the echoed response id decodes
+// as float64, so both must canonicalize to the same string.
+func normalizeRPCID(id interface{}) string {
+	switch v := id.(type) {
+	case float64:
+		if v == float64(int64(v)) {
+			return "n:" + strconv.FormatInt(int64(v), 10)
+		}
+		return "n:" + strconv.FormatFloat(v, 'g', -1, 64)
+	case int:
+		return "n:" + strconv.Itoa(v)
+	case int64:
+		return "n:" + strconv.FormatInt(v, 10)
+	case string:
+		return "s:" + v
+	default:
+		return fmt.Sprintf("o:%v", v)
+	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -862,3 +862,43 @@ func TestSendRequest_HTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP error 503")
 	assert.Contains(t, err.Error(), "Service Unavailable")
 }
+
+// Reordered batch responses must retain both their result and error association.
+func TestSendBatchReordersErrorResponsesByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqs []JSONRPCRequest
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&reqs))
+
+		w.Header().Set("Content-Type", "application/json")
+		responses := []*JSONRPCResponse{
+			NewJSONRPCErrorResponse(reqs[1].ID, InvalidParams, "invalid transaction", nil),
+			NewJSONRPCResponse(reqs[0].ID, "0xhash1"),
+		}
+		assert.NoError(t, json.NewEncoder(w).Encode(responses))
+	}))
+	defer server.Close()
+
+	batch := NewBatchRequest()
+	batch.Add("eth_sendRawTransaction", "0x76tx1")
+	batch.Add("eth_sendRawTransaction", "0x76tx2")
+
+	responses, err := New(server.URL).SendBatch(context.Background(), batch)
+	assert.NoError(t, err)
+	assert.Equal(t, "0xhash1", responses[0].Result)
+	assert.EqualError(t, responses[1].CheckError(), "RPC error -32602: invalid transaction")
+}
+
+func TestReorderBatchResponsesLeavesOmittedRequestNil(t *testing.T) {
+	requests := []*JSONRPCRequest{
+		NewJSONRPCRequest(1, "first"),
+		NewJSONRPCRequest(2, "second"),
+	}
+	responses := []*JSONRPCResponse{
+		NewJSONRPCResponse(float64(2), "second result"),
+		NewJSONRPCResponse(float64(99), "unknown result"),
+	}
+
+	ordered := reorderBatchResponses(requests, responses)
+	assert.Nil(t, ordered[0])
+	assert.Equal(t, "second result", ordered[1].Result)
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -862,3 +862,35 @@ func TestSendRequest_HTTPError(t *testing.T) {
 	assert.Contains(t, err.Error(), "HTTP error 503")
 	assert.Contains(t, err.Error(), "Service Unavailable")
 }
+
+func TestSendBatchReordersByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var reqs []JSONRPCRequest
+		err := json.NewDecoder(r.Body).Decode(&reqs)
+		assert.NoError(t, err)
+		assert.Len(t, reqs, 2)
+
+		w.Header().Set("Content-Type", "application/json")
+		// Return responses in REVERSED order to simulate a spec-compliant server
+		// that does not preserve request ordering.
+		responses := []*JSONRPCResponse{
+			NewJSONRPCResponse(reqs[1].ID, "0xhash2"),
+			NewJSONRPCResponse(reqs[0].ID, "0xhash1"),
+		}
+		json.NewEncoder(w).Encode(responses)
+	}))
+	defer server.Close()
+
+	client := New(server.URL)
+
+	batch := NewBatchRequest()
+	batch.Add("eth_sendRawTransaction", "0x76tx1")
+	batch.Add("eth_sendRawTransaction", "0x76tx2")
+
+	responses, err := client.SendBatch(context.Background(), batch)
+	assert.NoError(t, err)
+	assert.Len(t, responses, 2)
+	// Despite the server reversing the reply, results must align with request order.
+	assert.Equal(t, "0xhash1", responses[0].Result)
+	assert.Equal(t, "0xhash2", responses[1].Result)
+}


### PR DESCRIPTION
## Motivation

Self-contained companion coverage for https://github.com/tempoxyz/tempo-go/pull/67.

## Summary

- Carry batch response ID correlation with coverage for reordered errors and omitted responses.
- Add the required patch changelog.

## Key design considerations

- Includes the implementation so CI validates the coverage from main.