### PR TITLE
test(transaction): cover sponsored fee payer trailer decoding

### DIFF
--- a/.changelog/cover-feepayer-trailer-decoding.md
+++ b/.changelog/cover-feepayer-trailer-decoding.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Detect and remove only genuine fee-payer trailers, preserving transaction data that ends with the trailer marker.

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -1,6 +1,7 @@
 package transaction
 
 import (
+	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -57,19 +58,17 @@ func Deserialize(serialized string) (*Tx, error) {
 	// Remove 76 prefix
 	serialized = serialized[2:]
 
-	// tempo.ts v0.4.2+ appends sender address + marker when feePayer=true
-	// Format: <rlp_data> + <20_byte_address> + "feefeefeefee"
-	// We need to strip this before RLP decoding
-	if strings.HasSuffix(serialized, "feefeefeefee") && len(serialized) >= 52 {
-		// 52 = 40 chars (20 bytes address) + 12 chars (6 bytes marker)
-		serialized = serialized[:len(serialized)-52]
-	}
-
 	// Decode hex to bytes
 	rlpBytes, err := hex.DecodeString(serialized)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode hex: %w", err)
 	}
+
+	// tempo.ts v0.4.2+ appends a sender address + marker after the RLP payload when
+	// feePayer=true: <rlp_data> || <20-byte address> || 0xfeefeefeefee. Strip it before
+	// RLP decoding, but detect it structurally rather than by a naive byte-suffix match,
+	// so we never truncate a legitimate transaction whose payload ends in those bytes.
+	rlpBytes = stripFeePayerTrailer(rlpBytes)
 
 	// Decode RLP to raw interface slice
 	var raw []interface{}
@@ -219,6 +218,36 @@ func Deserialize(serialized string) (*Tx, error) {
 	}
 
 	return tx, nil
+}
+
+// feePayerTrailerMarker is the 6-byte marker that tempo.ts (v0.4.2+) appends after the
+// 20-byte sender address when serializing a fee-payer transaction. The trailer lives
+// outside the RLP payload, so it must be removed before RLP decoding.
+var feePayerTrailerMarker = []byte{0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee}
+
+// feePayerTrailerLen is the total trailer size: a 20-byte address plus the marker.
+const feePayerTrailerLen = common.AddressLength + len("feefeefeefee")/2
+
+// stripFeePayerTrailer removes the tempo.ts fee-payer trailer, but only when it is
+// genuinely present. The check is structural: the marker must match AND the bytes that
+// precede it must form a single, self-contained RLP value with nothing left over. If
+// stripping would not leave a clean RLP value, the marker bytes were part of the real
+// payload (e.g. a WebAuthn signature that happens to end in 0xfeefeefeefee), so the
+// input is returned untouched. RLP decoding then reports any genuine corruption.
+func stripFeePayerTrailer(rlpBytes []byte) []byte {
+	if len(rlpBytes) < feePayerTrailerLen {
+		return rlpBytes
+	}
+	if !bytes.HasSuffix(rlpBytes, feePayerTrailerMarker) {
+		return rlpBytes
+	}
+
+	candidate := rlpBytes[:len(rlpBytes)-feePayerTrailerLen]
+	if _, rest, err := rlp.SplitList(candidate); err != nil || len(rest) != 0 {
+		// Removing the trailer does not yield a clean RLP list: the marker was real data.
+		return rlpBytes
+	}
+	return candidate
 }
 
 // parseSignatureEnvelopeField parses a signature envelope from a raw RLP field.

--- a/pkg/transaction/feepayer_trailer_coverage_test.go
+++ b/pkg/transaction/feepayer_trailer_coverage_test.go
@@ -1,0 +1,45 @@
+package transaction
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeserializeStripsTrailerWithoutChangingSponsoredTransaction(t *testing.T) {
+	recipient := common.HexToAddress("0x4444444444444444444444444444444444444444")
+	tx := New()
+	tx.Gas = 21000
+	tx.FeeToken = AlphaUSDAddress
+	tx.AwaitingFeePayer = true
+	tx.Calls = []Call{{To: &recipient, Value: nil, Data: []byte{0x01, 0x02}}}
+
+	serialized, err := Serialize(tx, nil)
+	require.NoError(t, err)
+	withTrailer := serialized + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" + "feefeefeefee"
+
+	got, err := Deserialize(withTrailer)
+	require.NoError(t, err)
+	assert.True(t, got.AwaitingFeePayer)
+	assert.Equal(t, AlphaUSDAddress, got.FeeToken)
+	require.Len(t, got.Calls, 1)
+	assert.Equal(t, []byte{0x01, 0x02}, got.Calls[0].Data)
+}
+
+func TestDeserializePreservesCallDataEndingInFeePayerMarker(t *testing.T) {
+	recipient := common.HexToAddress("0x5555555555555555555555555555555555555555")
+	marker := []byte{0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee}
+	tx := New()
+	tx.Gas = 21000
+	tx.Calls = []Call{{To: &recipient, Value: nil, Data: append([]byte{0x01, 0x02}, marker...)}}
+
+	serialized, err := Serialize(tx, nil)
+	require.NoError(t, err)
+
+	got, err := Deserialize(serialized)
+	require.NoError(t, err)
+	require.Len(t, got.Calls, 1)
+	assert.Equal(t, tx.Calls[0].Data, got.Calls[0].Data)
+}

--- a/pkg/transaction/feepayer_trailer_test.go
+++ b/pkg/transaction/feepayer_trailer_test.go
@@ -1,0 +1,64 @@
+package transaction
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+// buildSignedTxEndingInMarker returns a WebAuthn-signed transaction whose serialized
+// payload legitimately ends in the 0xfeefeefeefee marker bytes.
+func buildSignedTxEndingInMarker(t *testing.T) (*Tx, string) {
+	t.Helper()
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	raw := make([]byte, 129)
+	raw[0] = 0x02 // WebAuthn type prefix
+	copy(raw[len(raw)-6:], []byte{0xfe, 0xef, 0xee, 0xfe, 0xef, 0xee})
+
+	tx := New()
+	tx.Gas = 21000
+	tx.Calls = []Call{{To: &recipient, Value: nil, Data: []byte{}}}
+	tx.Signature = &signer.SignatureEnvelope{Type: "webauthn", Raw: raw}
+
+	serialized, err := Serialize(tx, nil)
+	require.NoError(t, err)
+	require.True(t, strings.HasSuffix(serialized, "feefeefeefee"),
+		"test setup: serialized tx should end in the marker bytes")
+	return tx, serialized
+}
+
+// A legitimate transaction whose payload ends in the marker bytes must NOT be truncated.
+func TestDeserializeDoesNotTruncateLegitMarkerSuffix(t *testing.T) {
+	tx, serialized := buildSignedTxEndingInMarker(t)
+
+	got, err := Deserialize(serialized)
+	require.NoError(t, err, "valid tx ending in marker bytes must still parse")
+	require.NotNil(t, got.Signature)
+	assert.Equal(t, tx.Signature.Raw, got.Signature.Raw,
+		"signature must survive the round trip intact")
+}
+
+// A genuine tempo.ts trailer (address + marker) must be stripped before decoding.
+func TestDeserializeStripsGenuineFeePayerTrailer(t *testing.T) {
+	recipient := common.HexToAddress("0x3333333333333333333333333333333333333333")
+	tx := New()
+	tx.Gas = 21000
+	tx.Calls = []Call{{To: &recipient, Value: nil, Data: []byte{}}}
+
+	serialized, err := Serialize(tx, nil)
+	require.NoError(t, err)
+
+	// Append <20-byte address> + marker, exactly as tempo.ts does.
+	withTrailer := serialized + strings.Repeat("0", 40) + "feefeefeefee"
+
+	got, err := Deserialize(withTrailer)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21000), got.Gas)
+	require.Len(t, got.Calls, 1)
+	assert.Equal(t, recipient, *got.Calls[0].To)
+}


### PR DESCRIPTION
## Motivation

Self-contained companion coverage for https://github.com/tempoxyz/tempo-go/pull/66.

## Summary

- Carry structural fee-payer trailer detection with coverage for genuine trailers and marker-suffixed call data.
- Add the required patch changelog.

## Key design considerations

- Includes the implementation so CI validates the coverage from main.