### PR TITLE
test(transaction): cover sponsored clone signing fields

### DIFF
--- a/.changelog/cover-sponsored-clone-signing.md
+++ b/.changelog/cover-sponsored-clone-signing.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Preserve the fee-payer sponsorship marker when cloning transactions so sender signing payloads remain valid.

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -231,6 +231,7 @@ func (tx *Tx) Clone() *Tx {
 		ValidBefore:          tx.ValidBefore,
 		ValidAfter:           tx.ValidAfter,
 		FeeToken:             tx.FeeToken,
+		AwaitingFeePayer:     tx.AwaitingFeePayer,
 		From:                 tx.From,
 	}
 

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -453,3 +453,24 @@ func TestTransaction_Clone(t *testing.T) {
 		assert.Empty(t, cloned.AccessList)
 	})
 }
+
+func TestClonePreservesAwaitingFeePayer(t *testing.T) {
+	recipient := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	tx := New()
+	tx.Gas = 21000
+	tx.MaxFeePerGas = big.NewInt(1_000_000_000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1_000_000_000)
+	tx.FeeToken = AlphaUSDAddress
+	tx.AwaitingFeePayer = true
+	tx.Calls = []Call{{To: &recipient, Value: big.NewInt(0), Data: []byte{}}}
+
+	clone := tx.Clone()
+	assert.True(t, clone.AwaitingFeePayer, "clone must preserve AwaitingFeePayer")
+
+	origHash, err := GetSignPayload(tx)
+	assert.NoError(t, err)
+	cloneHash, err := GetSignPayload(clone)
+	assert.NoError(t, err)
+	assert.Equal(t, origHash, cloneHash, "clone must produce the same signing payload as the original")
+}

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -1,10 +1,12 @@
 package transaction
 
 import (
+	"encoding/hex"
 	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/assert"
 	"github.com/tempoxyz/tempo-go/pkg/signer"
 )
@@ -452,4 +454,32 @@ func TestTransaction_Clone(t *testing.T) {
 		assert.Empty(t, cloned.Calls)
 		assert.Empty(t, cloned.AccessList)
 	})
+}
+
+// A cloned sponsored transaction must retain the special sender-signing encoding.
+func TestClonePreservesSponsoredSigningFields(t *testing.T) {
+	recipient := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	tx := New()
+	tx.Gas = 21000
+	tx.MaxFeePerGas = big.NewInt(1_000_000_000)
+	tx.MaxPriorityFeePerGas = big.NewInt(1_000_000_000)
+	tx.FeeToken = AlphaUSDAddress
+	tx.AwaitingFeePayer = true
+	tx.Calls = []Call{{To: &recipient, Value: big.NewInt(0), Data: []byte{}}}
+
+	serialized, err := SerializeForSigning(tx.Clone())
+	if !assert.NoError(t, err) {
+		return
+	}
+	raw, err := hex.DecodeString(serialized[4:])
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var fields []interface{}
+	if !assert.NoError(t, rlp.DecodeBytes(raw, &fields)) {
+		return
+	}
+	assert.Empty(t, fields[10], "sponsored sender signing payload must omit fee token")
+	assert.Equal(t, []byte{0x00}, fields[11], "sponsored sender signing payload must retain marker")
 }


### PR DESCRIPTION
## Motivation

Self-contained companion coverage for https://github.com/tempoxyz/tempo-go/pull/65.

## Summary

- Carry the sponsored clone fix with focused signing-format coverage.
- Add the required patch changelog.

## Key design considerations

- Includes the implementation so CI validates the coverage from main.