### PR TITLE
feat: add T8 Committee

### DIFF
--- a/.changelog/t8-current-committee.md
+++ b/.changelog/t8-current-committee.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: minor
+---
+
+Add a typed client query for the T8 CurrentCommittee precompile.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,10 @@ jobs:
         exit 1
 
     - name: Run integration tests (localnet lacks fee token liquidity for on-chain tests)
-      run: go test -v -run "TestIntegration_NodeConnection|TestIntegration_BuilderValidation|TestIntegration_RoundTrip" -timeout=5m ./tests
+      run: go test -v -run "TestIntegration_NodeConnection|TestIntegration_BuilderValidation|TestIntegration_RoundTrip|TestIntegration_T8CurrentCommittee" -timeout=5m ./tests
       env:
         TEMPO_RPC_URL: http://localhost:8545
+        TEMPO_HARDFORK: T8
 
     - name: Show Tempo node logs on failure
       if: failure()

--- a/pkg/client/current_committee.go
+++ b/pkg/client/current_committee.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+)
+
+// CurrentCommitteeAddress is the address of the T8 CurrentCommittee precompile.
+const CurrentCommitteeAddress = "0xC077E00000000000000000000000000000000000"
+
+// GetCommitteeMembersSelector is the selector for getCommitteeMembers().
+const GetCommitteeMembersSelector = "0xb2a275f9"
+
+var currentCommitteeABI = mustParseCurrentCommitteeABI(`[{
+	"name": "getCommitteeMembers",
+	"type": "function",
+	"stateMutability": "view",
+	"inputs": [],
+	"outputs": [
+		{"name": "epoch", "type": "uint64"},
+		{"name": "publicKeys", "type": "bytes32[]"}
+	]
+}]`)
+
+func mustParseCurrentCommitteeABI(json string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(json))
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse CurrentCommittee ABI: %v", err))
+	}
+	return parsed
+}
+
+// GetCommitteeMembers returns the effective validator committee for the
+// current epoch. The public keys are ordered as selected by the DKG outcome.
+func (c *Client) GetCommitteeMembers(ctx context.Context) (epoch uint64, publicKeys [][32]byte, err error) {
+	callObject := map[string]string{
+		"to":   CurrentCommitteeAddress,
+		"data": GetCommitteeMembersSelector,
+	}
+
+	response, err := c.SendRequest(ctx, "eth_call", callObject, "latest")
+	if err != nil {
+		return 0, nil, err
+	}
+	if err := response.CheckError(); err != nil {
+		return 0, nil, err
+	}
+
+	resultHex, ok := response.Result.(string)
+	if !ok {
+		return 0, nil, fmt.Errorf("unexpected result type: %T", response.Result)
+	}
+	result, err := hex.DecodeString(strings.TrimPrefix(resultHex, "0x"))
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to decode getCommitteeMembers result: %w", err)
+	}
+
+	values, err := currentCommitteeABI.Unpack("getCommitteeMembers", result)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to decode getCommitteeMembers result: %w", err)
+	}
+	if len(values) != 2 {
+		return 0, nil, fmt.Errorf("expected 2 return values, got %d", len(values))
+	}
+
+	epoch, ok = values[0].(uint64)
+	if !ok {
+		return 0, nil, fmt.Errorf("unexpected epoch type: %T", values[0])
+	}
+	publicKeys, ok = values[1].([][32]byte)
+	if !ok {
+		return 0, nil, fmt.Errorf("unexpected public keys type: %T", values[1])
+	}
+	return epoch, publicKeys, nil
+}

--- a/pkg/client/current_committee_test.go
+++ b/pkg/client/current_committee_test.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCommitteeMembersSelector(t *testing.T) {
+	want := "0x" + hex.EncodeToString(crypto.Keccak256([]byte("getCommitteeMembers()"))[:4])
+	assert.Equal(t, want, GetCommitteeMembersSelector)
+}
+
+func TestGetCommitteeMembers(t *testing.T) {
+	wantEpoch := uint64(42)
+	wantPublicKeys := [][32]byte{{0x11}, {0x22}}
+	encoded, err := currentCommitteeABI.Methods["getCommitteeMembers"].Outputs.Pack(wantEpoch, wantPublicKeys)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req JSONRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "eth_call", req.Method)
+		require.Len(t, req.Params, 2)
+		callObject, ok := req.Params[0].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, CurrentCommitteeAddress, callObject["to"])
+		assert.Equal(t, GetCommitteeMembersSelector, callObject["data"])
+		assert.Equal(t, "latest", req.Params[1])
+
+		w.Header().Set("Content-Type", "application/json")
+		require.NoError(t, json.NewEncoder(w).Encode(NewJSONRPCResponse(req.ID, "0x"+hex.EncodeToString(encoded))))
+	}))
+	defer server.Close()
+
+	epoch, publicKeys, err := New(server.URL).GetCommitteeMembers(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, wantEpoch, epoch)
+	assert.Equal(t, wantPublicKeys, publicKeys)
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -76,7 +76,7 @@ func isT2() bool {
 
 func isT5OrLater() bool {
 	switch hardfork {
-	case "T5", "T6":
+	case "T5", "T6", "T7", "T8":
 		return true
 	default:
 		return false
@@ -84,7 +84,16 @@ func isT5OrLater() bool {
 }
 
 func isT6OrLater() bool {
-	return hardfork == "T6"
+	switch hardfork {
+	case "T6", "T7", "T8":
+		return true
+	default:
+		return false
+	}
+}
+
+func isT8OrLater() bool {
+	return hardfork == "T8"
 }
 
 // testContext encapsulates common test dependencies and helpers
@@ -959,7 +968,7 @@ func TestIntegration_T5KeyAuthorizationWitness(t *testing.T) {
 // separate AccountKeychain precompile call.
 func TestIntegration_T6KeyAuthorization(t *testing.T) {
 	if !isT6OrLater() {
-		t.Skip("requires TEMPO_HARDFORK=T6 and a T6-capable RPC")
+		t.Skip("requires TEMPO_HARDFORK=T6 or later and a T6-capable RPC")
 	}
 
 	tc := newTestContext(t)
@@ -1011,6 +1020,18 @@ func TestIntegration_T6KeyAuthorization(t *testing.T) {
 		assert.Equal(t, adminKey.Address(), parseKeyInfoKeyId(resultBytes),
 			"admin key not authorized via tx-embedded authorization")
 	})
+}
+
+// TestIntegration_T8CurrentCommittee queries the effective validator committee (TIP-1070).
+func TestIntegration_T8CurrentCommittee(t *testing.T) {
+	if !isT8OrLater() {
+		t.Skip("requires TEMPO_HARDFORK=T8 and a T8-capable RPC")
+	}
+
+	tc := newTestContext(t)
+	epoch, publicKeys, err := tc.client.GetCommitteeMembers(tc.ctx)
+	require.NoError(t, err)
+	t.Logf("Current committee epoch %d has %d members", epoch, len(publicKeys))
 }
 
 // TestIntegration_KeychainWithLimits tests authorizeKey with enforceLimits=true and a non-empty TokenLimit[]


### PR DESCRIPTION
Adds T8 CurrentCommittee support:

- Add the precompile address and typed committee query
- Decode epoch and ordered committee public keys
- Update integration hardfork ordering through T8
- Add unit and T8 integration coverage

Closes OSS-534