### PR TITLE
hardening: Enforce canonical RLP integer encodings on deserialize

### DIFF
--- a/.changelog/canonical-rlp-integers.md
+++ b/.changelog/canonical-rlp-integers.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Reject non-canonical (leading-zero) RLP integer encodings during transaction deserialization, preventing hash malleability and round-trip divergence.

--- a/pkg/transaction/canonical_rlp_test.go
+++ b/pkg/transaction/canonical_rlp_test.go
@@ -1,0 +1,79 @@
+package transaction
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func baseList(t *testing.T) []interface{} {
+	t.Helper()
+	to := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	tx := New()
+	tx.Gas = 21000
+	tx.MaxFeePerGas = big.NewInt(1)
+	tx.Calls = []Call{{To: &to, Value: big.NewInt(7), Data: []byte{}}}
+	list, err := buildRLPList(tx, &SerializeOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return list
+}
+
+func wire(t *testing.T, list []interface{}) string {
+	t.Helper()
+	raw, err := rlp.EncodeToBytes(list)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return "0x76" + hex.EncodeToString(raw)
+}
+
+func TestDeserialize_RejectsNonCanonicalIntegers(t *testing.T) {
+	cases := []struct {
+		name string
+		idx  int
+		val  []byte
+	}{
+		{"chainId", 0, []byte{0x00, 0x10, 0x79}},
+		{"maxPriorityFee", 1, []byte{0x00, 0x01}},
+		{"maxFee", 2, []byte{0x00, 0x01}},
+		{"gas", 3, []byte{0x00, 0x52, 0x08}},
+		{"nonceKey", 6, []byte{0x00, 0x01}},
+		{"nonce", 7, []byte{0x00, 0x05}},
+		{"validBefore", 8, []byte{0x00, 0x05}},
+		{"validAfter", 9, []byte{0x00, 0x05}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			list := baseList(t)
+			list[tc.idx] = tc.val
+			if _, err := Deserialize(wire(t, list)); err == nil {
+				t.Fatalf("%s: expected non-canonical integer to be rejected", tc.name)
+			}
+		})
+	}
+}
+
+func TestDeserialize_RejectsNonCanonicalCallValue(t *testing.T) {
+	list := baseList(t)
+	call := []interface{}{
+		common.HexToAddress("0x2222222222222222222222222222222222222222").Bytes(),
+		[]byte{0x00, 0x07}, // non-canonical value
+		[]byte{},
+	}
+	list[4] = []interface{}{call}
+	if _, err := Deserialize(wire(t, list)); err == nil {
+		t.Fatal("expected non-canonical call value to be rejected")
+	}
+}
+
+// Canonical encodings (incl. zero as empty string) still deserialize fine.
+func TestDeserialize_AcceptsCanonicalIntegers(t *testing.T) {
+	if _, err := Deserialize(wire(t, baseList(t))); err != nil {
+		t.Fatalf("canonical transaction rejected: %v", err)
+	}
+}

--- a/pkg/transaction/deserialize.go
+++ b/pkg/transaction/deserialize.go
@@ -86,21 +86,33 @@ func Deserialize(serialized string) (*Tx, error) {
 	// Parse fields in order
 	// Field 0: chainId
 	if chainID, ok := raw[0].([]byte); ok && len(chainID) > 0 {
+		if err := requireCanonicalInt(chainID, "chainId (field 0)"); err != nil {
+			return nil, err
+		}
 		tx.ChainID = new(big.Int).SetBytes(chainID)
 	}
 
 	// Field 1: maxPriorityFeePerGas
 	if maxPriorityFeePerGas, ok := raw[1].([]byte); ok && len(maxPriorityFeePerGas) > 0 {
+		if err := requireCanonicalInt(maxPriorityFeePerGas, "maxPriorityFeePerGas (field 1)"); err != nil {
+			return nil, err
+		}
 		tx.MaxPriorityFeePerGas = new(big.Int).SetBytes(maxPriorityFeePerGas)
 	}
 
 	// Field 2: maxFeePerGas
 	if maxFeePerGas, ok := raw[2].([]byte); ok && len(maxFeePerGas) > 0 {
+		if err := requireCanonicalInt(maxFeePerGas, "maxFeePerGas (field 2)"); err != nil {
+			return nil, err
+		}
 		tx.MaxFeePerGas = new(big.Int).SetBytes(maxFeePerGas)
 	}
 
 	// Field 3: gas
 	if gas, ok := raw[3].([]byte); ok && len(gas) > 0 {
+		if err := requireCanonicalInt(gas, "gas (field 3)"); err != nil {
+			return nil, err
+		}
 		v, err := bytesToUint64(gas)
 		if err != nil {
 			return nil, fmt.Errorf("gas %v", err)
@@ -128,11 +140,17 @@ func Deserialize(serialized string) (*Tx, error) {
 
 	// Field 6: nonceKey
 	if nonceKey, ok := raw[6].([]byte); ok && len(nonceKey) > 0 {
+		if err := requireCanonicalInt(nonceKey, "nonceKey (field 6)"); err != nil {
+			return nil, err
+		}
 		tx.NonceKey = new(big.Int).SetBytes(nonceKey)
 	}
 
 	// Field 7: nonce
 	if nonce, ok := raw[7].([]byte); ok && len(nonce) > 0 {
+		if err := requireCanonicalInt(nonce, "nonce (field 7)"); err != nil {
+			return nil, err
+		}
 		v, err := bytesToUint64(nonce)
 		if err != nil {
 			return nil, fmt.Errorf("nonce %v", err)
@@ -142,6 +160,9 @@ func Deserialize(serialized string) (*Tx, error) {
 
 	// Field 8: validBefore
 	if validBefore, ok := raw[8].([]byte); ok && len(validBefore) > 0 {
+		if err := requireCanonicalInt(validBefore, "validBefore (field 8)"); err != nil {
+			return nil, err
+		}
 		v, err := bytesToUint64(validBefore)
 		if err != nil {
 			return nil, fmt.Errorf("validBefore %v", err)
@@ -151,6 +172,9 @@ func Deserialize(serialized string) (*Tx, error) {
 
 	// Field 9: validAfter
 	if validAfter, ok := raw[9].([]byte); ok && len(validAfter) > 0 {
+		if err := requireCanonicalInt(validAfter, "validAfter (field 9)"); err != nil {
+			return nil, err
+		}
 		v, err := bytesToUint64(validAfter)
 		if err != nil {
 			return nil, fmt.Errorf("validAfter %v", err)
@@ -312,6 +336,9 @@ func decodeCalls(callsRaw []interface{}) ([]Call, error) {
 
 		// Field 1: value
 		if value, ok := callTuple[1].([]byte); ok && len(value) > 0 {
+			if err := requireCanonicalInt(value, fmt.Sprintf("call %d value", i)); err != nil {
+				return nil, err
+			}
 			call.Value = new(big.Int).SetBytes(value)
 		}
 
@@ -509,6 +536,20 @@ func decodeSignatureEnvelope(envelopeBytes []byte) (*signer.SignatureEnvelope, e
 	default:
 		return nil, fmt.Errorf("unknown signature type prefix: 0x%02x", typePrefix)
 	}
+}
+
+// requireCanonicalInt rejects non-canonical RLP integer encodings. RLP integers
+// must be the minimal big-endian byte string, so a leading zero byte is illegal
+// (0 is the empty string 0x80, 5 is 0x05, never 0x0005). When decoding into
+// []interface{} the RLP layer does not enforce this, so without the check a
+// non-canonical field would be accepted and then re-serialized in canonical form
+// — a byte-level mismatch that changes the transaction hash (malleability).
+func requireCanonicalInt(b []byte, field string) error {
+	if len(b) > 0 && b[0] == 0x00 {
+		return fmt.Errorf("%w: %s uses a non-canonical (leading-zero) integer encoding",
+			ErrInvalidTransaction, field)
+	}
+	return nil
 }
 
 // bytesToUint64 converts a byte slice to uint64, returning an error if it exceeds uint64 range.


### PR DESCRIPTION
# Enforce canonical RLP integer encodings on deserialize

Per the RLP specification, an integer is encoded as its shortest big-endian byte
string: zero is the empty string (`0x80`), and no positive integer may carry a
leading zero byte. The Tempo node treats a transaction's byte representation as
authoritative — the transaction hash is `keccak256` over exactly those bytes — so
two encodings that differ only by leading zeros are two different transactions,
even though they decode to the same numeric values.

`Deserialize` decodes the RLP payload into `[]interface{}`, at which layer
go-ethereum surfaces each scalar as a raw byte string and performs **no**
canonical-form check. Every numeric field was therefore parsed with
`new(big.Int).SetBytes` / `bytesToUint64`, both of which happily accept
`0x0005` and yield `5`. The consequences:

* **Malleability.** A third party could pad any scalar (`gas`, `nonce`,
  `maxFeePerGas`, …) with leading zeros, obtaining a distinct wire encoding — and
  thus a distinct hash — that still decodes to the identical logical transaction.
* **Round-trip divergence.** `Deserialize` followed by `Serialize` re-emits the
  canonical form, so the re-serialised bytes (and hash) no longer match the input
  the caller was handed.
* **Leniency versus the network.** The SDK accepted encodings a canonical-RLP
  node would reject.

This continues the anti-malleability hardening already present in the package
(rejection of legacy `V` values, high-S signatures, and malformed field-11
payloads).

## Change

A single `requireCanonicalInt` guard rejects any integer field whose first byte
is `0x00`. It is applied to fields 0–3 and 6–9 (chain id, both fee fields, gas,
nonce key, nonce, and the two validity timestamps) and to each call's `value`.
Zero remains the empty string and is unaffected; genuinely canonical
transactions — including the golden and vector fixtures — are untouched.

## Verification

New table-driven tests assert rejection of a non-canonical encoding for every
guarded field and for a call value, alongside a positive test proving canonical
transactions still decode. The complete `pkg/transaction` suite passes.
