### PR TITLE
fix(transaction): decode ComputeHash input strictly as hex

### DIFF
--- a/.changelog/computehash-strict-hex.md
+++ b/.changelog/computehash-strict-hex.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+`ComputeHash` now decodes its input strictly as hex (0x prefix optional) instead of silently hashing a non-prefixed string as raw bytes.

--- a/pkg/transaction/computehash_test.go
+++ b/pkg/transaction/computehash_test.go
@@ -1,0 +1,43 @@
+package transaction
+
+import (
+	"testing"
+)
+
+// ComputeHash must treat its input as hex, with or without the 0x prefix, and
+// must produce the same hash either way.
+func TestComputeHash_PrefixInvariant(t *testing.T) {
+	withPrefix, err := ComputeHash("0x76c0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	noPrefix, err := ComputeHash("76c0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withPrefix != noPrefix {
+		t.Fatalf("prefix should not change the hash: %s vs %s", withPrefix.Hex(), noPrefix.Hex())
+	}
+}
+
+// A non-hex string is rejected rather than silently hashed as raw bytes.
+func TestComputeHash_RejectsNonHex(t *testing.T) {
+	if _, err := ComputeHash("not-a-transaction"); err == nil {
+		t.Fatal("expected error for non-hex input, got nil")
+	}
+	if _, err := ComputeHash("0xZZ"); err == nil {
+		t.Fatal("expected error for invalid hex, got nil")
+	}
+}
+
+// A round-tripped, signed transaction still hashes consistently.
+func TestComputeHash_MatchesTxHash(t *testing.T) {
+	// hash of the canonical empty-ish payload is deterministic; ensure no error path
+	h, err := ComputeHash("0x76c0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h.Hex() == "" {
+		t.Fatal("empty hash")
+	}
+}

--- a/pkg/transaction/signing.go
+++ b/pkg/transaction/signing.go
@@ -1,7 +1,9 @@
 package transaction
 
 import (
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -10,8 +12,14 @@ import (
 
 // ComputeHash computes the Keccak256 hash of a serialized transaction.
 // This is useful for verifying transaction hashes or implementing custom signing logic.
+//
+// The input must be hex-encoded (the "0x" prefix is optional). A serialized Tempo
+// transaction is always hex, so the input is decoded strictly: a non-hex string is
+// rejected rather than being hashed as its raw UTF-8 bytes. The previous behavior
+// (via common.ParseHexOrString) silently fell back to hashing the literal string
+// when the "0x" prefix was missing, yielding a wrong-but-plausible hash with no error.
 func ComputeHash(serialized string) (common.Hash, error) {
-	serializedBytes, err := common.ParseHexOrString(serialized)
+	serializedBytes, err := hex.DecodeString(strings.TrimPrefix(serialized, "0x"))
 	if err != nil {
 		return common.Hash{}, fmt.Errorf("failed to parse serialized transaction: %w", err)
 	}


### PR DESCRIPTION
`ComputeHash` used `common.ParseHexOrString`, which decodes hex only when the
string carries a `0x` prefix and otherwise falls back to hashing the literal
bytes of the string. So `ComputeHash("76c0")` didn't hash the transaction
`0x76c0` — it hashed the four ASCII characters `7`, `6`, `c`, `0`, returning a
different hash with no error. A serialized Tempo transaction is always hex, so
that fallback only ever hides a mistake behind a plausible-looking wrong hash.

Now the input is decoded strictly as hex (the `0x` prefix stays optional):

- `ComputeHash("0x76c0")` and `ComputeHash("76c0")` return the same hash.
- Non-hex input (`"oops"`, `"0xZZ"`) returns an error instead of a bogus hash.

Existing callers already pass `0x`-prefixed output from `Serialize`, so their
behaviour is unchanged; the full `pkg/transaction` suite still passes.
fix(transaction): decode ComputeHash input strictly as hex