### PR TITLE
fix(keychain): validate spending-limit amounts before abi.Pack

### DIFF
--- a/.changelog/keychain-amount-validation.md
+++ b/.changelog/keychain-amount-validation.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Validate token amounts in `KeyRestrictions.Validate` and `UpdateSpendingLimit` so nil, negative, or over-uint256 values return an error instead of panicking inside ABI packing.

--- a/pkg/keychain/calls.go
+++ b/pkg/keychain/calls.go
@@ -401,6 +401,17 @@ func RemoveAllowedCalls(keyID common.Address, target common.Address) (Call, erro
 
 // UpdateSpendingLimit builds an updateSpendingLimit(address,address,uint256) call.
 func UpdateSpendingLimit(keyID common.Address, token common.Address, newLimit *big.Int) (Call, error) {
+	// Guard the amount before it reaches abi.Pack: a nil *big.Int panics with a
+	// reflect error, and negative / over-uint256 values are not encodable.
+	if newLimit == nil {
+		return Call{}, fmt.Errorf("newLimit must not be nil")
+	}
+	if newLimit.Sign() < 0 {
+		return Call{}, fmt.Errorf("newLimit must be non-negative")
+	}
+	if newLimit.BitLen() > 256 {
+		return Call{}, fmt.Errorf("newLimit exceeds uint256")
+	}
 	data, err := updateSpendingLimitABI.Pack("updateSpendingLimit", keyID, token, newLimit)
 	if err != nil {
 		return Call{}, fmt.Errorf("failed to encode updateSpendingLimit: %w", err)

--- a/pkg/keychain/restrictions.go
+++ b/pkg/keychain/restrictions.go
@@ -235,6 +235,21 @@ func (kr *KeyRestrictions) Validate() error {
 	if kr.allowAnyCalls && len(kr.allowedCalls) > 0 {
 		return errors.New("allowedCalls was provided but allowAnyCalls=true; set allowAnyCalls=false to create a scoped key")
 	}
+	// Validate spending-limit amounts. Without this, a nil amount reaches
+	// abi.Pack (which panics with a cryptic reflect error), and negative or
+	// over-uint256 values would encode incorrectly. This mirrors the checks in
+	// KeyAuthorization.Validate.
+	for i, l := range kr.limits {
+		if l.Amount == nil {
+			return fmt.Errorf("limits[%d].amount must not be nil", i)
+		}
+		if l.Amount.Sign() < 0 {
+			return fmt.Errorf("limits[%d].amount must be non-negative", i)
+		}
+		if l.Amount.BitLen() > 256 {
+			return fmt.Errorf("limits[%d].amount exceeds uint256", i)
+		}
+	}
 	// Reject duplicate targets — order-dependent IsCallAllowed behaviour is confusing.
 	seen := make(map[common.Address]struct{}, len(kr.allowedCalls))
 	for _, s := range kr.allowedCalls {

--- a/pkg/keychain/spending_limit_validation_test.go
+++ b/pkg/keychain/spending_limit_validation_test.go
@@ -1,0 +1,59 @@
+package keychain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	testKey   = common.HexToAddress("0x1111111111111111111111111111111111111111")
+	testToken = common.HexToAddress("0x20c0000000000000000000000000000000000001")
+)
+
+func TestKeyRestrictions_Validate_RejectsBadLimitAmounts(t *testing.T) {
+	over := new(big.Int).Lsh(big.NewInt(1), 256) // 2^256, exceeds uint256
+
+	cases := map[string]*big.Int{
+		"nil":      nil,
+		"negative": big.NewInt(-1),
+		"overflow": over,
+	}
+	for name, amt := range cases {
+		t.Run(name, func(t *testing.T) {
+			kr := NewKeyRestrictions(0).WithLimits([]TokenLimit{{Token: testToken, Amount: amt}})
+			if err := kr.Validate(); err == nil {
+				t.Fatalf("expected Validate to reject %s amount", name)
+			}
+		})
+	}
+}
+
+// AuthorizeKey must return an error (not panic) for an invalid limit amount.
+func TestAuthorizeKey_NilLimitAmountReturnsError(t *testing.T) {
+	kr := NewKeyRestrictions(0).WithLimits([]TokenLimit{{Token: testToken, Amount: nil}})
+	if _, err := AuthorizeKey(testKey, SignatureTypeSecp256k1, kr); err == nil {
+		t.Fatal("expected AuthorizeKey to return an error for nil limit amount")
+	}
+}
+
+// A valid limit still packs successfully.
+func TestAuthorizeKey_ValidLimitSucceeds(t *testing.T) {
+	kr := NewKeyRestrictions(0).WithLimits([]TokenLimit{{Token: testToken, Amount: big.NewInt(1000)}})
+	if _, err := AuthorizeKey(testKey, SignatureTypeSecp256k1, kr); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestUpdateSpendingLimit_RejectsBadAmounts(t *testing.T) {
+	if _, err := UpdateSpendingLimit(testKey, testToken, nil); err == nil {
+		t.Fatal("expected error for nil newLimit")
+	}
+	if _, err := UpdateSpendingLimit(testKey, testToken, big.NewInt(-5)); err == nil {
+		t.Fatal("expected error for negative newLimit")
+	}
+	if _, err := UpdateSpendingLimit(testKey, testToken, big.NewInt(500)); err != nil {
+		t.Fatalf("unexpected error for valid newLimit: %v", err)
+	}
+}


### PR DESCRIPTION
# fix(keychain): validate token amounts before ABI packing

### 🐛 The bug

Two exported entry points passed a caller-supplied `*big.Int` token amount
straight into `abi.Pack` with no validation:

1. `AuthorizeKey` / `AuthorizeKeyWithWitness` → `KeyRestrictions.Validate()`
   never checked `TokenLimit.Amount`.
2. `UpdateSpendingLimit` never checked `newLimit`.

A `nil` amount doesn't return the function's declared `error` — it **panics**
deep inside go-ethereum:

```
panic: reflect: call of reflect.Value.Type on zero Value
```

Negative and `> uint256` values are likewise not encodable.

`KeyAuthorization.Validate()` already performs exactly these checks, so the
keychain call builders were inconsistent with the package's own authorization
type.

### ✅ The fix

- `KeyRestrictions.Validate()` now rejects `nil`, negative, and over-`uint256`
  limit amounts (same rules as `KeyAuthorization.Validate`).
- `UpdateSpendingLimit` guards `newLimit` before packing.

Both now return a descriptive `error` instead of panicking.

### 🧪 Tests

`spending_limit_validation_test.go` covers nil / negative / overflow amounts for
`KeyRestrictions.Validate`, `AuthorizeKey`, and `UpdateSpendingLimit`, plus
happy-path packing. `pkg/keychain` suite is green.
