### PR TITLE
keychain: validate inner signature in BuildKeychainSignature

### DIFF
--- a/.changelog/keychain-signature-guard.md
+++ b/.changelog/keychain-signature-guard.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: minor
+---
+
+`BuildKeychainSignature` now returns `([]byte, error)` and rejects nil or over-32-byte R/S components instead of panicking or silently corrupting the signature.

--- a/pkg/keychain/build_signature_guard_test.go
+++ b/pkg/keychain/build_signature_guard_test.go
@@ -1,0 +1,55 @@
+package keychain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func TestBuildKeychainSignature_RejectsBadScalars(t *testing.T) {
+	root := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	oversized := new(big.Int).SetBytes(make([]byte, 33)) // needs a leading byte
+	oversized.SetBit(oversized, 8*33-1, 1)               // 33 significant bytes
+
+	cases := map[string]*signer.Signature{
+		"nil R":       {R: nil, S: big.NewInt(1)},
+		"nil S":       {R: big.NewInt(1), S: nil},
+		"oversized R": {R: oversized, S: big.NewInt(1)},
+		"oversized S": {R: big.NewInt(1), S: oversized},
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildKeychainSignature(sig, root); err == nil {
+				t.Fatalf("expected error for %s", name)
+			}
+		})
+	}
+}
+
+func TestBuildKeychainSignature_NilSignature(t *testing.T) {
+	if _, err := BuildKeychainSignature(nil, common.Address{}); err == nil {
+		t.Fatal("expected error for nil signature")
+	}
+}
+
+// A valid signature still round-trips through Parse.
+func TestBuildKeychainSignature_ValidRoundTrip(t *testing.T) {
+	root := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	sig := signer.NewSignature(big.NewInt(0x1234), big.NewInt(0x5678), 1)
+	b, err := BuildKeychainSignature(sig, root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, parsedRoot, inner, err := ParseKeychainSignature(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsedRoot != root {
+		t.Fatalf("root mismatch: %s", parsedRoot.Hex())
+	}
+	if inner.R.Cmp(big.NewInt(0x1234)) != 0 || inner.S.Cmp(big.NewInt(0x5678)) != 0 {
+		t.Fatalf("R/S mismatch: %s %s", inner.R, inner.S)
+	}
+}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -34,8 +34,24 @@ const (
 //   - innerSig: The secp256k1 signature from the access key
 //   - rootAccount: The address of the root account (the account the access key acts on behalf of)
 //
-// Returns the 86-byte Keychain signature.
-func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Address) []byte {
+// Returns the 86-byte Keychain signature, or an error if innerSig is malformed.
+//
+// The R and S components must be present and fit in 32 bytes. A nil scalar would
+// otherwise panic on Bytes(); an over-32-byte scalar previously produced a
+// negative slice bound (panic) or wrote past the reserved region, silently
+// corrupting the embedded root account and R/S into a structurally valid but
+// unverifiable signature. This matches the scalar guard in signer.RecoverAddress.
+func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Address) ([]byte, error) {
+	if innerSig == nil || innerSig.R == nil || innerSig.S == nil {
+		return nil, fmt.Errorf("inner signature and its R/S components must be non-nil")
+	}
+	if l := len(innerSig.R.Bytes()); l > 32 {
+		return nil, fmt.Errorf("inner signature R exceeds 32 bytes (got %d)", l)
+	}
+	if l := len(innerSig.S.Bytes()); l > 32 {
+		return nil, fmt.Errorf("inner signature S exceeds 32 bytes (got %d)", l)
+	}
+
 	result := make([]byte, KeychainSignatureLength)
 
 	// Byte 0: Keychain V2 signature type (0x04)
@@ -44,19 +60,16 @@ func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Addre
 	// Bytes 1-20: Root account address
 	copy(result[1:21], rootAccount.Bytes())
 
-	// Bytes 21-85: Inner signature (r || s || v)
-	// R: 32 bytes
-	rBytes := innerSig.R.Bytes()
-	copy(result[21+(32-len(rBytes)):53], rBytes)
+	// Bytes 21-52: R (left-padded to 32 bytes)
+	innerSig.R.FillBytes(result[21:53])
 
-	// S: 32 bytes
-	sBytes := innerSig.S.Bytes()
-	copy(result[53+(32-len(sBytes)):85], sBytes)
+	// Bytes 53-84: S (left-padded to 32 bytes)
+	innerSig.S.FillBytes(result[53:85])
 
-	// V: 1 byte (yParity)
+	// Byte 85: V (yParity)
 	result[85] = innerSig.YParity
 
-	return result
+	return result, nil
 }
 
 // SignWithAccessKey signs a Tempo transaction using an access key.
@@ -108,7 +121,10 @@ func SignWithAccessKey(tx *transaction.Tx, accessKeySigner *signer.Signer, rootA
 	}
 
 	// Build the Keychain signature
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		return fmt.Errorf("failed to build keychain signature: %w", err)
+	}
 
 	// Create a signature envelope with the raw Keychain signature bytes
 	tx.Signature = &signer.SignatureEnvelope{

--- a/pkg/keychain/keychain_test.go
+++ b/pkg/keychain/keychain_test.go
@@ -28,7 +28,10 @@ func TestBuildKeychainSignature(t *testing.T) {
 	innerSig := signer.NewSignature(r, s, yParity)
 	rootAccount := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		t.Fatalf("BuildKeychainSignature: %v", err)
+	}
 
 	// Verify length
 	if len(keychainSig) != KeychainSignatureLength {
@@ -63,7 +66,10 @@ func TestParseKeychainSignature(t *testing.T) {
 	innerSig := signer.NewSignature(r, s, yParity)
 	rootAccount := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		t.Fatalf("BuildKeychainSignature: %v", err)
+	}
 
 	// Parse it back
 	sigType, parsedRoot, parsedInner, err := ParseKeychainSignature(keychainSig)


### PR DESCRIPTION
# Harden BuildKeychainSignature against malformed inner signatures

While tracing how an access-key signature gets assembled, I noticed that
`BuildKeychainSignature` trusts its `*signer.Signature` argument completely. It
does this to place R and S into the 86-byte layout:

```go
rBytes := innerSig.R.Bytes()
copy(result[21+(32-len(rBytes)):53], rBytes)
```

That low bound, `21 + (32 - len(rBytes))`, is only valid when the scalar fits in
32 bytes. I convinced myself there were three separate ways this goes wrong, and
then wrote a probe for each:

- **nil R or S** → `innerSig.R.Bytes()` dereferences nil and panics.
- **R longer than 53 bytes (or S longer than 85)** → the bound goes negative and
  the copy panics with `slice bounds out of range [-1:]`.
- **R of 33–52 bytes** → no panic, but the write starts *before* offset 21,
  scribbling over the tail of the embedded root account. You get a
  structurally-valid 86-byte blob that carries the wrong root and wrong R, and it
  simply fails verification later with no hint as to why.

The normal path (`SignWithAccessKey` → `signer.Sign`) always yields clean 32-byte
scalars, so this only bites callers who hand-build a `Signature` or feed one from
a remote/hardware signer — exactly the callers least able to debug a silent
corruption. It's also inconsistent with `signer.RecoverAddress`, which already
guards scalar length explicitly.

## What changed

`BuildKeychainSignature` now returns `([]byte, error)`. It rejects nil and
over-32-byte R/S up front, and uses `FillBytes` for the fixed-width placement so
the offsets can't drift. `SignWithAccessKey` propagates the error (it never
triggers it in practice). The two existing unit tests were updated for the new
signature, and I added `build_signature_guard_test.go` covering the nil and
oversized cases plus a valid round-trip.

Because the exported signature changed, this is a minor (not patch) bump.
keychain: validate inner signature in BuildKeychainSignature