### PR TITLE
fix(client): nil-safe, order-independent client options

### DIFF
--- a/.changelog/client-option-robustness.md
+++ b/.changelog/client-option-robustness.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Make client construction robust: `WithHTTPClient(nil)` is ignored instead of causing a panic, and `WithTimeout` is applied regardless of option order so a later `WithHTTPClient` no longer discards it.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,10 +22,11 @@ const (
 
 // Client is a basic HTTP client for interacting with the Tempo blockchain.
 type Client struct {
-	rpcURL     string
-	username   string
-	password   string
-	httpClient *http.Client
+	rpcURL          string
+	username        string
+	password        string
+	httpClient      *http.Client
+	timeoutOverride *time.Duration
 }
 
 // Option is a functional option for configuring the Client.
@@ -40,16 +41,25 @@ func WithAuth(username, password string) Option {
 }
 
 // WithTimeout configures the HTTP timeout for the client.
+//
+// The timeout is recorded and applied after all options are processed, so it is
+// honored regardless of option order — a WithHTTPClient supplied afterwards can
+// no longer silently discard it. An explicit WithTimeout also takes precedence
+// over any timeout carried by a custom client passed via WithHTTPClient.
 func WithTimeout(timeout time.Duration) Option {
 	return func(c *Client) {
-		c.httpClient.Timeout = timeout
+		c.timeoutOverride = &timeout
 	}
 }
 
-// WithHTTPClient configures a custom HTTP client.
+// WithHTTPClient configures a custom HTTP client. A nil client is ignored so the
+// default client (or an earlier WithHTTPClient) is preserved instead of leaving
+// the client in a nil state that would panic on the first request.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(c *Client) {
-		c.httpClient = httpClient
+		if httpClient != nil {
+			c.httpClient = httpClient
+		}
 	}
 }
 
@@ -65,6 +75,17 @@ func New(rpcURL string, opts ...Option) *Client {
 
 	for _, opt := range opts {
 		opt(c)
+	}
+
+	// Defensive: never leave the client without an HTTP client to use.
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{Timeout: defaultTimeout}
+	}
+
+	// Apply an explicit timeout last so it survives WithHTTPClient regardless of
+	// the order the options were provided in.
+	if c.timeoutOverride != nil {
+		c.httpClient.Timeout = *c.timeoutOverride
 	}
 
 	return c

--- a/pkg/client/option_robustness_test.go
+++ b/pkg/client/option_robustness_test.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+// WithHTTPClient(nil) must not leave the client in a nil state.
+func TestNew_NilHTTPClientIsIgnored(t *testing.T) {
+	c := New("http://example.invalid", WithHTTPClient(nil))
+	if c.httpClient == nil {
+		t.Fatal("httpClient is nil after WithHTTPClient(nil)")
+	}
+	// Combined with WithTimeout, the constructor must not panic.
+	c2 := New("http://example.invalid", WithHTTPClient(nil), WithTimeout(5*time.Second))
+	if c2.httpClient == nil || c2.httpClient.Timeout != 5*time.Second {
+		t.Fatalf("expected 5s timeout on a non-nil client, got %+v", c2.httpClient)
+	}
+}
+
+// WithTimeout must survive a later WithHTTPClient (order-independent).
+func TestNew_TimeoutSurvivesLaterHTTPClient(t *testing.T) {
+	custom := &http.Client{Timeout: 99 * time.Second}
+	c := New("http://example.invalid", WithTimeout(3*time.Second), WithHTTPClient(custom))
+	if c.httpClient.Timeout != 3*time.Second {
+		t.Fatalf("explicit WithTimeout was discarded: got %s", c.httpClient.Timeout)
+	}
+}
+
+// A custom client without an explicit WithTimeout keeps its own timeout.
+func TestNew_CustomClientTimeoutPreserved(t *testing.T) {
+	custom := &http.Client{Timeout: 42 * time.Second}
+	c := New("http://example.invalid", WithHTTPClient(custom))
+	if c.httpClient.Timeout != 42*time.Second {
+		t.Fatalf("custom client timeout not preserved: got %s", c.httpClient.Timeout)
+	}
+}
+
+// The default client still gets the default timeout.
+func TestNew_DefaultTimeout(t *testing.T) {
+	c := New("http://example.invalid")
+	if c.httpClient.Timeout != defaultTimeout {
+		t.Fatalf("expected default timeout %s, got %s", defaultTimeout, c.httpClient.Timeout)
+	}
+}


### PR DESCRIPTION
# Make client options nil-safe and order-independent

## What

- [x] `WithHTTPClient(nil)` no longer leaves the client in a nil state
- [x] `WithTimeout` is applied after all options, so it survives a later `WithHTTPClient`
- [x] `New` guarantees a non-nil `http.Client`
- [x] Added regression tests for each case

## Why

Two footguns lived in the constructor's option handling:

- [x] **Nil client panic.** `WithHTTPClient` assigned its argument unconditionally.
      `New(url, WithHTTPClient(nil), WithTimeout(5*time.Second))` panicked *inside
      the constructor* (`WithTimeout` dereferenced the nil client), and
      `New(url, WithHTTPClient(nil))` panicked on the first request.
- [x] **Order-dependent timeout.** `WithTimeout` mutated the current client, so
      `New(url, WithTimeout(3*time.Second), WithHTTPClient(custom))` silently
      dropped the 3s timeout — the later custom client replaced the one it was set on.

## How

- `WithHTTPClient` ignores a nil argument.
- `WithTimeout` records the value; `New` applies it once, after every option, and
  guarantees a non-nil client. An explicit `WithTimeout` now wins over a timeout
  baked into a custom client, regardless of the order the options are passed.

## Testing

- [x] `pkg/client` suite passes (existing `WithTimeout` / `WithHTTPClient` tests unchanged)
- [x] New `option_robustness_test.go` covers nil client, order independence,
      custom-client preservation, and the default timeout
