### PR TITLE
fix(client): surface top-level batch error object in SendBatch

### DIFF
--- a/.changelog/sendbatch-toplevel-error.md
+++ b/.changelog/sendbatch-toplevel-error.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+`SendBatch` now surfaces a top-level JSON-RPC error object (returned when a whole batch is rejected) as a `*JSONRPCError`, instead of masking it behind a generic unmarshal error.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -384,6 +384,13 @@ func (c *Client) SendBatch(ctx context.Context, batch *BatchRequest) ([]*JSONRPC
 
 	var responses []*JSONRPCResponse
 	if err := json.Unmarshal(responseBody, &responses); err != nil {
+		// A batch that fails as a whole (e.g. a parse or invalid-request error)
+		// is returned by a compliant server as a single JSON-RPC error object,
+		// not an array. Surface that error instead of an opaque unmarshal failure.
+		var single JSONRPCResponse
+		if jsonErr := json.Unmarshal(responseBody, &single); jsonErr == nil && single.Error != nil {
+			return nil, fmt.Errorf("batch request rejected: %w", single.Error)
+		}
 		return nil, fmt.Errorf("failed to unmarshal batch response: %w", err)
 	}
 

--- a/pkg/client/sendbatch_toplevel_error_test.go
+++ b/pkg/client/sendbatch_toplevel_error_test.go
@@ -1,0 +1,51 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// When a batch fails as a whole, a server may return a single JSON-RPC error
+// object rather than an array. SendBatch must surface that error's code/message
+// instead of an opaque "failed to unmarshal" message.
+func TestSendBatch_TopLevelErrorObjectSurfaced(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid batch"}}`))
+	}))
+	defer server.Close()
+
+	batch := NewBatchRequest()
+	batch.Add("eth_blockNumber")
+
+	_, err := New(server.URL).SendBatch(context.Background(), batch)
+	if err == nil {
+		t.Fatal("expected an error for a top-level batch error object")
+	}
+
+	var rpcErr *JSONRPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("expected a *JSONRPCError to be surfaced, got: %v", err)
+	}
+	if rpcErr.Code != -32600 || rpcErr.Message != "invalid batch" {
+		t.Fatalf("wrong error surfaced: code=%d msg=%q", rpcErr.Code, rpcErr.Message)
+	}
+}
+
+// A genuinely malformed (non-JSON) body still returns the unmarshal error.
+func TestSendBatch_MalformedBodyStillErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`not json at all`))
+	}))
+	defer server.Close()
+
+	batch := NewBatchRequest()
+	batch.Add("eth_blockNumber")
+
+	if _, err := New(server.URL).SendBatch(context.Background(), batch); err == nil {
+		t.Fatal("expected an error for a malformed batch body")
+	}
+}


### PR DESCRIPTION
# Surface top-level JSON-RPC errors from SendBatch

**What's the problem?**

When an entire batch is rejected, a spec-compliant JSON-RPC 2.0 server responds
with a single error *object* rather than an array of responses — for example:

```json
{"jsonrpc":"2.0","id":null,"error":{"code":-32600,"message":"invalid batch"}}
```

`SendBatch` only ever tried to unmarshal the body into `[]*JSONRPCResponse`. That
unmarshal fails on an object, so the caller received
`failed to unmarshal batch response: json: cannot unmarshal object into Go value
of type []*client.JSONRPCResponse` — the server's actual code and message were
thrown away.

**Why does it matter?**

The real reason the batch was rejected (bad request, parse error, auth, etc.) is
exactly what the caller needs to act on. Replacing it with a generic
deserialization error makes these failures needlessly hard to diagnose.

**How is it fixed?**

If the array unmarshal fails, `SendBatch` now attempts to decode the body as a
single `JSONRPCResponse`. If that yields an `Error`, it is returned (wrapped, so
`errors.As` recovers the `*JSONRPCError` with its code and message). A body that
is neither an array nor an error object still returns the original unmarshal
error. The per-response reordering path is unchanged.

**Tests**

`sendbatch_toplevel_error_test.go` asserts that a top-level error object is
surfaced as a `*JSONRPCError` (via `errors.As`) and that a genuinely malformed
body still errors.