### PR TITLE
fix(transaction): guard Serialize against nil signature R/S

### DIFF
--- a/.changelog/serialize-nil-signature-guard.md
+++ b/.changelog/serialize-nil-signature-guard.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+`Serialize` now returns an error instead of panicking when a transaction's sender or fee-payer signature has a nil R or S component.

--- a/pkg/transaction/serialize.go
+++ b/pkg/transaction/serialize.go
@@ -103,7 +103,11 @@ func buildRLPList(tx *Tx, opts *SerializeOptions) ([]interface{}, error) {
 	)
 
 	// Field 11: feePayerSignatureOrSender
-	rlpList = append(rlpList, encodeFeePayerField(tx, opts))
+	feePayerField, err := encodeFeePayerField(tx, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode fee payer field: %w", err)
+	}
+	rlpList = append(rlpList, feePayerField)
 
 	// Field 12: authorizationList (empty for now)
 	rlpList = append(rlpList, []interface{}{})
@@ -146,14 +150,19 @@ func encodeFeeTokenConditional(token common.Address, skip bool) []byte {
 
 // encodeFeePayerField encodes field 11 (feePayerSignatureOrSender).
 // The encoding depends on the serialization format and whether a fee payer signature exists.
-func encodeFeePayerField(tx *Tx, opts *SerializeOptions) interface{} {
+func encodeFeePayerField(tx *Tx, opts *SerializeOptions) (interface{}, error) {
 	// For fee payer signing format (0x78), include sender address
 	if opts.Format == FormatFeePayer {
-		return opts.Sender.Bytes()
+		return opts.Sender.Bytes(), nil
 	}
 
 	// If transaction has fee payer signature, encode it as [yParity, r, s]
 	if tx.FeePayerSignature != nil {
+		// Guard against a directly-assembled Signature whose R or S is nil:
+		// (*big.Int)(nil).Bytes() panics, so reject it instead of crashing Serialize.
+		if tx.FeePayerSignature.R == nil || tx.FeePayerSignature.S == nil {
+			return nil, fmt.Errorf("fee payer signature R and S must not be nil")
+		}
 		var yParityBytes []byte
 		if tx.FeePayerSignature.YParity != 0 {
 			yParityBytes = []byte{tx.FeePayerSignature.YParity}
@@ -162,16 +171,16 @@ func encodeFeePayerField(tx *Tx, opts *SerializeOptions) interface{} {
 			yParityBytes,
 			tx.FeePayerSignature.R.Bytes(),
 			tx.FeePayerSignature.S.Bytes(),
-		}
+		}, nil
 	}
 
 	// If awaiting fee payer, use 0x00 marker
 	if tx.AwaitingFeePayer {
-		return []byte{0x00}
+		return []byte{0x00}, nil
 	}
 
 	// No fee payer signature - use empty byte array
-	return []byte{}
+	return []byte{}, nil
 }
 
 // encodeWithPrefix encodes the RLP list and adds the appropriate TempoTransaction type prefix.
@@ -324,6 +333,11 @@ func encodeSignatureEnvelope(envelope *signer.SignatureEnvelope) ([]byte, error)
 	if envelope.Type == "secp256k1" || envelope.Type == "" {
 		if envelope.Signature == nil {
 			return nil, fmt.Errorf("secp256k1 signature envelope has no parsed signature")
+		}
+
+		// Guard against nil R/S: (*big.Int)(nil).Bytes() panics.
+		if envelope.Signature.R == nil || envelope.Signature.S == nil {
+			return nil, fmt.Errorf("secp256k1 signature R and S must not be nil")
 		}
 
 		rBytes := envelope.Signature.R.Bytes()

--- a/pkg/transaction/serialize_nil_signature_test.go
+++ b/pkg/transaction/serialize_nil_signature_test.go
@@ -1,0 +1,61 @@
+package transaction
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+// A directly-assembled Tx whose fee-payer signature has a nil R or S must not
+// crash Serialize with a nil-pointer panic; it must return an error instead.
+func TestSerialize_FeePayerSignatureNilScalar(t *testing.T) {
+	cases := map[string]*signer.Signature{
+		"nil R": {R: nil, S: big.NewInt(1)},
+		"nil S": {R: big.NewInt(1), S: nil},
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			tx := New()
+			tx.ChainID = big.NewInt(4217)
+			tx.FeePayerSignature = sig
+			if _, err := Serialize(tx, nil); err == nil {
+				t.Fatalf("expected error for %s, got nil", name)
+			}
+		})
+	}
+}
+
+// Same guarantee for the sender signature envelope.
+func TestSerialize_SenderSignatureNilScalar(t *testing.T) {
+	cases := map[string]*signer.Signature{
+		"nil R": {R: nil, S: big.NewInt(1)},
+		"nil S": {R: big.NewInt(1), S: nil},
+	}
+	for name, sig := range cases {
+		t.Run(name, func(t *testing.T) {
+			tx := New()
+			tx.ChainID = big.NewInt(4217)
+			tx.Signature = &signer.SignatureEnvelope{Type: "secp256k1", Signature: sig}
+			if _, err := Serialize(tx, nil); err == nil {
+				t.Fatalf("expected error for %s, got nil", name)
+			}
+		})
+	}
+}
+
+// A valid fee-payer signature still serializes without error.
+func TestSerialize_FeePayerSignatureValid(t *testing.T) {
+	tx := New()
+	tx.ChainID = big.NewInt(4217)
+	tx.FeePayerSignature = &signer.Signature{R: big.NewInt(0x1234), S: big.NewInt(0x5678), YParity: 1}
+
+	out, err := Serialize(tx, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(out, "0x76") {
+		t.Fatalf("expected 0x76 prefix, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

`Serialize` panics with a nil-pointer dereference when a transaction carries a
sender or fee-payer signature whose `R` or `S` component is `nil`:

```
panic: runtime error: invalid memory address or nil pointer dereference
math/big.(*Int).Bytes(0x0)
```

A `Tx` assembled directly (`&Tx{...}`, or setting `FeePayerSignature` /
`Signature` by hand) is a legal state, so this crashes the caller instead of
returning the function's declared `error`. This is the same class of nil-safety
issue as #79 (`Tx.Clone`) and #84 (`BuildKeychainSignature`).

## Reproduction

```go
tx := transaction.New()
tx.ChainID = big.NewInt(4217)
tx.FeePayerSignature = &signer.Signature{R: nil, S: big.NewInt(1)} // legal struct
_, _ = transaction.Serialize(tx, nil) // panics
```

The sender path panics the same way via
`tx.Signature = &signer.SignatureEnvelope{Type: "secp256k1", Signature: &signer.Signature{R: nil, ...}}`.

## Fix

`encodeFeePayerField` and `encodeSignatureEnvelope` now reject a nil `R` or `S`
and return an error, which `buildRLPList` propagates — no source of the panic
remains.

## Tests

Added `serialize_nil_signature_test.go`: fee-payer and sender signatures with a
nil `R`/`S` now return an error instead of panicking, and a valid signature
still serializes (0x76 prefix).

## Checks

```
make check   # gofmt -l . clean, go vet ./..., go test -race ./pkg/... all pass
```

## AI assistance disclosure

This change (the fix, test, and changelog) was written primarily with Claude Code
(Claude Fable 5). I directed the work, reviewed the output, reproduced the panic,
and ran `make check` locally to confirm everything passes.
