### PR TITLE
fix: validate keychain signature scalars with fuzz coverage

### DIFF
--- a/.changelog/keychain-signature-guard.md
+++ b/.changelog/keychain-signature-guard.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: minor
+---
+
+`BuildKeychainSignature` now returns `([]byte, error)` and rejects nil or over-32-byte R/S components instead of panicking or silently corrupting the signature.

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 
 # Run all fuzz tests sequentially
 fuzz-all:
-	@for pkg in ./pkg/transaction ./pkg/signer; do \
+	@for pkg in ./pkg/transaction ./pkg/signer ./pkg/keychain; do \
 		echo "=== Fuzzing $$pkg ==="; \
 		for test in $$(go test -list 'Fuzz.*' $$pkg 2>/dev/null | grep '^Fuzz'); do \
 			echo "Running $$test..."; \

--- a/pkg/keychain/build_signature_guard_test.go
+++ b/pkg/keychain/build_signature_guard_test.go
@@ -1,0 +1,51 @@
+package keychain
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func TestBuildKeychainSignatureRejectsMalformedScalars(t *testing.T) {
+	oversized := new(big.Int).Lsh(big.NewInt(1), 256)
+	tests := []struct {
+		name string
+		sig  *signer.Signature
+	}{
+		{name: "nil signature"},
+		{name: "nil R", sig: signer.NewSignature(nil, big.NewInt(1), 0)},
+		{name: "nil S", sig: signer.NewSignature(big.NewInt(1), nil, 0)},
+		{name: "oversized R", sig: signer.NewSignature(oversized, big.NewInt(1), 0)},
+		{name: "oversized S", sig: signer.NewSignature(big.NewInt(1), oversized, 0)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if result, err := BuildKeychainSignature(test.sig, common.Address{}); err == nil {
+				t.Fatalf("BuildKeychainSignature() = %x, nil; want error", result)
+			}
+		})
+	}
+}
+
+func TestBuildKeychainSignatureRoundTrip(t *testing.T) {
+	root := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	want := signer.NewSignature(big.NewInt(0x1234), big.NewInt(0x5678), 1)
+
+	encoded, err := BuildKeychainSignature(want, root)
+	if err != nil {
+		t.Fatalf("BuildKeychainSignature() error = %v", err)
+	}
+	_, gotRoot, got, err := ParseKeychainSignature(encoded)
+	if err != nil {
+		t.Fatalf("ParseKeychainSignature() error = %v", err)
+	}
+	if gotRoot != root {
+		t.Fatalf("ParseKeychainSignature() root = %s; want %s", gotRoot, root)
+	}
+	if got.R.Cmp(want.R) != 0 || got.S.Cmp(want.S) != 0 || got.YParity != want.YParity {
+		t.Fatalf("ParseKeychainSignature() signature = %+v; want %+v", got, want)
+	}
+}

--- a/pkg/keychain/fuzz_test.go
+++ b/pkg/keychain/fuzz_test.go
@@ -1,0 +1,47 @@
+package keychain
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/tempoxyz/tempo-go/pkg/signer"
+)
+
+func FuzzBuildKeychainSignature(f *testing.F) {
+	f.Add([]byte{1}, []byte{2})
+	f.Add(bytes.Repeat([]byte{0xff}, 32), bytes.Repeat([]byte{0xff}, 32))
+	f.Add(bytes.Repeat([]byte{0xff}, 33), []byte{1})
+	f.Add([]byte{1}, bytes.Repeat([]byte{0xff}, 33))
+	f.Add(bytes.Repeat([]byte{0xff}, 54), bytes.Repeat([]byte{0xff}, 86))
+
+	root := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
+	f.Fuzz(func(t *testing.T, rBytes, sBytes []byte) {
+		if len(rBytes) > 128 || len(sBytes) > 128 {
+			return
+		}
+
+		sig := signer.NewSignature(new(big.Int).SetBytes(rBytes), new(big.Int).SetBytes(sBytes), 1)
+		encoded, err := BuildKeychainSignature(sig, root)
+		if len(sig.R.Bytes()) > 32 || len(sig.S.Bytes()) > 32 {
+			if err == nil {
+				t.Fatalf("BuildKeychainSignature(%+v) returned %x; want error", sig, encoded)
+			}
+			return
+		}
+		if err != nil {
+			t.Fatalf("BuildKeychainSignature(%+v) error = %v", sig, err)
+		}
+		_, gotRoot, got, err := ParseKeychainSignature(encoded)
+		if err != nil {
+			t.Fatalf("ParseKeychainSignature() error = %v", err)
+		}
+		if gotRoot != root {
+			t.Fatalf("root = %s; want %s", gotRoot, root)
+		}
+		if got.R.Cmp(sig.R) != 0 || got.S.Cmp(sig.S) != 0 || got.YParity != sig.YParity {
+			t.Fatalf("round-trip signature = %+v; want %+v", got, sig)
+		}
+	})
+}

--- a/pkg/keychain/keychain.go
+++ b/pkg/keychain/keychain.go
@@ -34,8 +34,18 @@ const (
 //   - innerSig: The secp256k1 signature from the access key
 //   - rootAccount: The address of the root account (the account the access key acts on behalf of)
 //
-// Returns the 86-byte Keychain signature.
-func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Address) []byte {
+// Returns the 86-byte Keychain signature, or an error if innerSig is malformed.
+func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Address) ([]byte, error) {
+	if innerSig == nil || innerSig.R == nil || innerSig.S == nil {
+		return nil, fmt.Errorf("inner signature and its R/S components must be non-nil")
+	}
+	if l := len(innerSig.R.Bytes()); l > 32 {
+		return nil, fmt.Errorf("inner signature R exceeds 32 bytes (got %d)", l)
+	}
+	if l := len(innerSig.S.Bytes()); l > 32 {
+		return nil, fmt.Errorf("inner signature S exceeds 32 bytes (got %d)", l)
+	}
+
 	result := make([]byte, KeychainSignatureLength)
 
 	// Byte 0: Keychain V2 signature type (0x04)
@@ -44,19 +54,16 @@ func BuildKeychainSignature(innerSig *signer.Signature, rootAccount common.Addre
 	// Bytes 1-20: Root account address
 	copy(result[1:21], rootAccount.Bytes())
 
-	// Bytes 21-85: Inner signature (r || s || v)
-	// R: 32 bytes
-	rBytes := innerSig.R.Bytes()
-	copy(result[21+(32-len(rBytes)):53], rBytes)
+	// Bytes 21-52: R (left-padded to 32 bytes)
+	innerSig.R.FillBytes(result[21:53])
 
-	// S: 32 bytes
-	sBytes := innerSig.S.Bytes()
-	copy(result[53+(32-len(sBytes)):85], sBytes)
+	// Bytes 53-84: S (left-padded to 32 bytes)
+	innerSig.S.FillBytes(result[53:85])
 
-	// V: 1 byte (yParity)
+	// Byte 85: V (yParity)
 	result[85] = innerSig.YParity
 
-	return result
+	return result, nil
 }
 
 // SignWithAccessKey signs a Tempo transaction using an access key.
@@ -108,7 +115,10 @@ func SignWithAccessKey(tx *transaction.Tx, accessKeySigner *signer.Signer, rootA
 	}
 
 	// Build the Keychain signature
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		return fmt.Errorf("failed to build keychain signature: %w", err)
+	}
 
 	// Create a signature envelope with the raw Keychain signature bytes
 	tx.Signature = &signer.SignatureEnvelope{

--- a/pkg/keychain/keychain_test.go
+++ b/pkg/keychain/keychain_test.go
@@ -28,7 +28,10 @@ func TestBuildKeychainSignature(t *testing.T) {
 	innerSig := signer.NewSignature(r, s, yParity)
 	rootAccount := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		t.Fatalf("BuildKeychainSignature: %v", err)
+	}
 
 	// Verify length
 	if len(keychainSig) != KeychainSignatureLength {
@@ -63,7 +66,10 @@ func TestParseKeychainSignature(t *testing.T) {
 	innerSig := signer.NewSignature(r, s, yParity)
 	rootAccount := common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8")
 
-	keychainSig := BuildKeychainSignature(innerSig, rootAccount)
+	keychainSig, err := BuildKeychainSignature(innerSig, rootAccount)
+	if err != nil {
+		t.Fatalf("BuildKeychainSignature: %v", err)
+	}
 
 	// Parse it back
 	sigType, parsedRoot, parsedInner, err := ParseKeychainSignature(keychainSig)


### PR DESCRIPTION
## Motivation

BuildKeychainSignature assumes R and S fit in 32 bytes. Malformed signatures from external signers can therefore panic or silently overwrite the embedded root account. This carries forward the validation from #84 and adds fuzz coverage for future regressions.

## Summary

- return an error for nil or oversized signature scalars
- encode accepted scalars with fixed-width FillBytes calls
- cover malformed inputs with table-driven regression tests
- fuzz mutable R/S values across valid, corruption, and panic boundaries
- include keychain fuzzing in fuzz-all

## Key design considerations

- preserve the existing 86-byte wire format for valid signatures
- expose malformed input through an error, requiring a minor version bump
- keep the fuzz target fast and deterministic by mutating only R and S