### PR TITLE
fix(transaction): handle nil big integers in clone

### DIFF
--- a/.changelog/fix-clone-nil-bigints.md
+++ b/.changelog/fix-clone-nil-bigints.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Prevent `Tx.Clone` from panicking when transaction or call `big.Int` fields are nil.

--- a/pkg/transaction/fuzz_test.go
+++ b/pkg/transaction/fuzz_test.go
@@ -157,3 +157,71 @@ func FuzzSignedTransactionRoundTrip(f *testing.F) {
 		assert.Equal(t, sgn.Address(), recoveredAddr)
 	})
 }
+
+func FuzzClone(f *testing.F) {
+	for _, nilMask := range []uint8{0, 1, 2, 4, 8, 16, 31} {
+		f.Add(nilMask, []byte{0x01}, []byte{0xaa})
+	}
+
+	f.Fuzz(func(t *testing.T, nilMask uint8, integerBytes, callData []byte) {
+		if len(integerBytes) > 64 || len(callData) > 4096 {
+			return
+		}
+
+		newInt := func(offset int64) *big.Int {
+			return new(big.Int).Add(new(big.Int).SetBytes(integerBytes), big.NewInt(offset))
+		}
+
+		tx := &Tx{
+			ChainID:              newInt(1),
+			MaxPriorityFeePerGas: newInt(2),
+			MaxFeePerGas:         newInt(3),
+			NonceKey:             newInt(4),
+			Calls:                []Call{{Value: newInt(5), Data: callData}},
+		}
+		if nilMask&1 != 0 {
+			tx.ChainID = nil
+		}
+		if nilMask&2 != 0 {
+			tx.MaxPriorityFeePerGas = nil
+		}
+		if nilMask&4 != 0 {
+			tx.MaxFeePerGas = nil
+		}
+		if nilMask&8 != 0 {
+			tx.NonceKey = nil
+		}
+		if nilMask&16 != 0 {
+			tx.Calls[0].Value = nil
+		}
+
+		cloned := tx.Clone()
+		assertBigIntClone := func(name string, original, clone *big.Int) {
+			t.Helper()
+			if original == nil {
+				if clone != nil {
+					t.Errorf("%s: cloned nil value as %v", name, clone)
+				}
+				return
+			}
+			if clone == nil {
+				t.Errorf("%s: cloned non-nil value as nil", name)
+				return
+			}
+			if original == clone {
+				t.Errorf("%s: clone aliases original", name)
+			}
+			expected := new(big.Int).Set(original)
+			original.Add(original, big.NewInt(1))
+			if clone.Cmp(expected) != 0 {
+				t.Errorf("%s: clone changed after original mutation: got %v, want %v", name, clone, expected)
+			}
+		}
+
+		assertBigIntClone("chain ID", tx.ChainID, cloned.ChainID)
+		assertBigIntClone("max priority fee per gas", tx.MaxPriorityFeePerGas, cloned.MaxPriorityFeePerGas)
+		assertBigIntClone("max fee per gas", tx.MaxFeePerGas, cloned.MaxFeePerGas)
+		assertBigIntClone("nonce key", tx.NonceKey, cloned.NonceKey)
+		assertBigIntClone("call value", tx.Calls[0].Value, cloned.Calls[0].Value)
+	})
+}

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -222,11 +222,11 @@ func (tx *Tx) Hash() (common.Hash, error) {
 //	tx2.Calls = []transaction.Call{{To: &recipient2, Value: amount2}}
 func (tx *Tx) Clone() *Tx {
 	clone := &Tx{
-		ChainID:              new(big.Int).Set(tx.ChainID),
-		MaxPriorityFeePerGas: new(big.Int).Set(tx.MaxPriorityFeePerGas),
-		MaxFeePerGas:         new(big.Int).Set(tx.MaxFeePerGas),
+		ChainID:              copyBigInt(tx.ChainID),
+		MaxPriorityFeePerGas: copyBigInt(tx.MaxPriorityFeePerGas),
+		MaxFeePerGas:         copyBigInt(tx.MaxFeePerGas),
 		Gas:                  tx.Gas,
-		NonceKey:             new(big.Int).Set(tx.NonceKey),
+		NonceKey:             copyBigInt(tx.NonceKey),
 		Nonce:                tx.Nonce,
 		ValidBefore:          tx.ValidBefore,
 		ValidAfter:           tx.ValidAfter,
@@ -239,7 +239,7 @@ func (tx *Tx) Clone() *Tx {
 	clone.Calls = make([]Call, len(tx.Calls))
 	for i, call := range tx.Calls {
 		clone.Calls[i] = Call{
-			Value: new(big.Int).Set(call.Value),
+			Value: copyBigInt(call.Value),
 			Data:  append([]byte{}, call.Data...),
 		}
 		if call.To != nil {
@@ -266,6 +266,13 @@ func (tx *Tx) Clone() *Tx {
 	// Signature and FeePayerSignature remain nil in the clone
 
 	return clone
+}
+
+func copyBigInt(n *big.Int) *big.Int {
+	if n == nil {
+		return nil
+	}
+	return new(big.Int).Set(n)
 }
 
 // cloneRLPList recursively deep-copies RLP-like structures ([]interface{} and []byte).

--- a/pkg/transaction/transaction_test.go
+++ b/pkg/transaction/transaction_test.go
@@ -454,6 +454,37 @@ func TestTransaction_Clone(t *testing.T) {
 		assert.Empty(t, cloned.Calls)
 		assert.Empty(t, cloned.AccessList)
 	})
+
+	t.Run("clone nil big integers", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			original  *Tx
+			assertNil func(*testing.T, *Tx)
+		}{
+			{
+				name:     "zero value transaction",
+				original: &Tx{},
+				assertNil: func(t *testing.T, cloned *Tx) {
+					assert.Nil(t, cloned.ChainID)
+					assert.Nil(t, cloned.MaxPriorityFeePerGas)
+					assert.Nil(t, cloned.MaxFeePerGas)
+					assert.Nil(t, cloned.NonceKey)
+				},
+			},
+			{
+				name:      "call value",
+				original:  &Tx{Calls: []Call{{Value: nil}}},
+				assertNil: func(t *testing.T, cloned *Tx) { assert.Nil(t, cloned.Calls[0].Value) },
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				cloned := test.original.Clone()
+				test.assertNil(t, cloned)
+			})
+		}
+	})
 }
 
 // A cloned sponsored transaction must retain the special sender-signing encoding.


### PR DESCRIPTION
## Motivation

Cloning partially assembled transactions currently panics when transaction or call numeric fields are nil.

Supersedes #79 with regression and fuzz coverage.

## Summary

- Preserve nil `big.Int` fields while cloning transactions and calls
- Add regression coverage for zero-value transactions and nil call values
- Add fuzz coverage for nil combinations and deep-copy invariants
- Add a patch changelog entry

## Key design considerations

- Retain nil values instead of substituting zero values
- Preserve independent copies for every non-nil `big.Int`