### PR TITLE
test(keychain): use inline authorization

### DIFF
--- a/.changelog/tip1099-integration-authorization.md
+++ b/.changelog/tip1099-integration-authorization.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Updated live keychain integration coverage to use transaction-embedded authorization on TIP-1099 networks.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -715,34 +715,19 @@ func TestIntegration_AccessKeys(t *testing.T) {
 	t.Logf("Access key: %s", accessKey.Address().Hex())
 
 	t.Run("AuthorizeAccessKey", func(t *testing.T) {
-		calldata := buildAuthorizeKeyCalldata(accessKey.Address(), farFutureKeyExpiry, false)
+		tx := tc.newTxBuilder().
+			SetNonce(tc.getNonce(rootAccount.Address())).
+			SetGas(600000).
+			AddCall(counterContract, big.NewInt(0), incrementSelector).
+			Build()
 
-		eip1559Tx := types.NewTx(&types.DynamicFeeTx{
-			ChainID:   big.NewInt(tc.chainID),
-			Nonce:     tc.getNonce(rootAccount.Address()),
-			GasTipCap: tc.gasPrice,
-			GasFeeCap: tc.gasPrice,
-			Gas:       600000,
-			To:        &accountKeychain,
-			Value:     big.NewInt(0),
-			Data:      calldata,
-		})
+		auth := keychain.NewKeyAuthorization(
+			uint64(tc.chainID), keychain.SignatureTypeSecp256k1, accessKey.Address(),
+		).WithExpiry(uint64(farFutureKeyExpiry))
+		require.NoError(t, auth.SignAndAttach(tx, rootAccount))
+		require.NoError(t, transaction.SignTransaction(tx, rootAccount))
 
-		signedTx, err := types.SignTx(eip1559Tx, types.NewLondonSigner(big.NewInt(tc.chainID)), rootAccount.PrivateKey())
-		require.NoError(t, err)
-
-		txBytes, err := signedTx.MarshalBinary()
-		require.NoError(t, err)
-
-		txHash, err := tc.client.SendRawTransaction(tc.ctx, "0x"+hex.EncodeToString(txBytes))
-		require.NoError(t, err)
-		t.Logf("Authorize access key tx hash: %s", txHash)
-
-		receipt := tc.waitForReceipt(txHash)
-		require.NotNil(t, receipt, "Failed to get authorization receipt")
-		status, _ := receipt["status"].(string)
-		require.Equal(t, "0x1", status, "Authorization tx failed")
-		tc.formatReceipt(receipt)
+		tc.sendTxExpectSuccess(tx, "Transaction key authorization failed")
 	})
 
 	time.Sleep(3 * time.Second)
@@ -824,8 +809,8 @@ func parseABIEncodedBool(t *testing.T, result string) bool {
 	return false
 }
 
-// TestIntegration_KeychainSelectors tests that keychain selectors work against the precompile
-func TestIntegration_KeychainSelectors(t *testing.T) {
+// TestIntegration_KeychainLifecycle tests inline authorization followed by keychain queries and revocation.
+func TestIntegration_KeychainLifecycle(t *testing.T) {
 	tc := newTestContext(t)
 
 	rootAccount := tc.createAndFundSigner()
@@ -838,17 +823,19 @@ func TestIntegration_KeychainSelectors(t *testing.T) {
 	t.Logf("Root account: %s", rootAccount.Address().Hex())
 	t.Logf("Access key: %s", accessKey.Address().Hex())
 
-	// Step 1: Authorize the key with enforceLimits=false, empty TokenLimit[]
-	authCalldata := buildAuthorizeKeyCalldata(accessKey.Address(), expiry, false)
-
+	// Step 1: Authorize through the transaction key_authorization field. TIP-1099 removes
+	// the direct authorizeKey precompile selectors at T11.
 	authTx := tc.newTxBuilder().
 		SetNonce(tc.getNonce(rootAccount.Address())).
 		SetGas(600000).
-		AddCall(accountKeychain, big.NewInt(0), authCalldata).
+		AddCall(counterContract, big.NewInt(0), incrementSelector).
 		Build()
 
-	err = transaction.SignTransaction(authTx, rootAccount)
-	require.NoError(t, err)
+	auth := keychain.NewKeyAuthorization(
+		uint64(tc.chainID), keychain.SignatureTypeSecp256k1, accessKey.Address(),
+	).WithExpiry(uint64(expiry))
+	require.NoError(t, auth.SignAndAttach(authTx, rootAccount))
+	require.NoError(t, transaction.SignTransaction(authTx, rootAccount))
 
 	receipt := tc.sendTxExpectSuccess(authTx, "Authorization tx failed")
 	require.NotNil(t, receipt)


### PR DESCRIPTION
Updates access-key and keychain lifecycle integration tests to provision keys through the transaction `key_authorization` field. This preserves access-key signing, `getKey`, and revocation coverage after TIP-1099 removes direct `authorizeKey` selectors.

This PR was authored by OpenAI Codex under DaniPopes's direction.

Prompted by: @DaniPopes
