### PR TITLE
fix(ci): remove unused integration test import

### DIFF
--- a/.changelog/fix-integration-test-import.md
+++ b/.changelog/fix-integration-test-import.md
@@ -1,0 +1,5 @@
+---
+github.com/tempoxyz/tempo-go: patch
+---
+
+Restored live integration test compilation after switching keychain setup to transaction-embedded authorization.

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Removes the stale `go-ethereum/core/types` import left by the TIP-1099 integration-test rewrite. That unused import is the sole failure in both tempo-go lanes of `tempo-tests-5j6nb`.

Prompted by: @emmajam
