### PR TITLE
ci: switch to first-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        uses: tempoxyz/gh-actions/actions/gh-release@ab45d76f6e7420a094281a22aee1973ecc0754f8
         with:
           body: ${{ steps.changelog.outputs.notes }}
-          generate_release_notes: false
+          generate-release-notes: false


### PR DESCRIPTION
## Summary

Switches this repository's workflows from third-party actions to the equivalent first-party composites in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions), pinned to a full commit SHA. Inputs and outputs are unchanged unless noted below.

| Before | After |
| --- | --- |
| `softprops/action-gh-release` | [`tempoxyz/gh-actions/actions/gh-release`](https://github.com/tempoxyz/gh-actions/tree/ab45d76f6e7420a094281a22aee1973ecc0754f8/actions/gh-release) |

## Notes

- **gh-release**: inputs use the composite's kebab-case names (`tag`, `generate-release-notes`); behaviour is otherwise the same (create or update the release, upload assets with `--clobber`).

## Verification

- `actionlint` and `zizmor` (regular persona, offline) report no new findings after the change (actionlint 1 -> 1, zizmor 8 -> 7).
